### PR TITLE
feat(recognition): port model architecture and config

### DIFF
--- a/tsl_recognition/__init__.py
+++ b/tsl_recognition/__init__.py
@@ -1,0 +1,21 @@
+"""
+Turkish Sign Language Recognition (TSL-R) pipeline.
+
+This package implements a complete pipeline for sign language recognition using
+MediaPipe landmarks and deep learning sequence models.
+
+Pipeline stages:
+    1. Extraction  -- Extract face, hand, and pose landmarks from sign videos
+    2. Split       -- Generate persistent train/val/test split manifests
+    3. Training    -- Train a sequence model to classify signs from landmark sequences
+    4. Inference   -- Recognize signs in real-time from webcam or video files
+    5. Validation  -- Verify preprocessing consistency between training and inference
+
+Package structure:
+    config          - Configuration constants, paths, hyperparameters
+    models/         - Model registry and architecture implementations (GRU, ...)
+    dataset/        - Dataset registry, LazySignDataset, scaler, DataLoaders, augmentation
+    extraction/     - Video processing, MediaPipe landmarker setup, keypoint extraction
+    evaluation/     - Training loop, evaluation, inference, validation, visualization
+    cli             - CLI entry point for all pipeline commands
+"""

--- a/tsl_recognition/config.py
+++ b/tsl_recognition/config.py
@@ -1,0 +1,338 @@
+"""
+Configuration constants, path resolution, and hyperparameters.
+
+All tuneable knobs for the TSL recognition pipeline live here so every other
+module just does ``from tsl_recognition.config import cfg`` (or imports
+individual values).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+
+if TYPE_CHECKING:
+    from .dataset.base import DatasetInfo
+
+# ---------------------------------------------------------------------------
+# Reproducibility
+# ---------------------------------------------------------------------------
+SEED = 42
+
+
+def set_seed(seed: int = SEED) -> None:
+    """Set random seeds for reproducibility across all libraries.
+
+    Call this at the beginning of each training run to ensure deterministic
+    behaviour regardless of prior RNG state.
+
+    Parameters
+    ----------
+    seed : int, optional
+        Random seed value (default: ``SEED``).
+    """
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+# ---------------------------------------------------------------------------
+# Device
+# ---------------------------------------------------------------------------
+os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = "rtsp_transport;tcp|stimeout;5000000"
+
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_base_dir() -> Path:
+    """Determine the project root directory.
+
+    Resolution order:
+      1. ``PROJECT_ROOT`` environment variable (if set).
+      2. Parent of the ``tsl_recognition`` package directory (auto-detected).
+      3. Current working directory as a fallback.
+
+    Returns
+    -------
+    Path
+        The resolved project root directory.
+    """
+    # 1. Explicit environment variable
+    env_root = os.environ.get("PROJECT_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.exists():
+            return p
+
+    # 2. Auto-detect from package location: tsl_recognition/ lives one level below root
+    pkg_dir = Path(__file__).resolve().parent   # .../sozia-research/tsl_recognition
+    candidate = pkg_dir.parent                  # .../sozia-research
+    if (candidate / "tsl_recognition").is_dir():
+        return candidate
+
+    # 3. Fallback
+    return Path.cwd()
+
+
+BASE_DIR = _resolve_base_dir()
+
+# ---------------------------------------------------------------------------
+# Data paths
+# ---------------------------------------------------------------------------
+# Set DATA_ROOT to point to the directory containing your dataset folders
+# (e.g., BosphorusSign22k/, AUTSL/). Defaults to BASE_DIR / "data".
+DATA_ROOT = Path(os.environ.get("DATA_ROOT", BASE_DIR / "data"))
+
+# MediaPipe model directory (downloaded automatically on first use)
+MP_MODEL_DIR = BASE_DIR / "mp-models"
+
+# Trained-model output directory
+MODELS_DIR = BASE_DIR / "trained-models"
+
+# ---------------------------------------------------------------------------
+# MediaPipe model URLs
+# ---------------------------------------------------------------------------
+MODEL_URLS = {
+    "face": "https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/latest/face_landmarker.task",
+    "hand": "https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/latest/hand_landmarker.task",
+    "pose": "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_full/float16/latest/pose_landmarker_full.task",
+}
+
+# ---------------------------------------------------------------------------
+# Landmark dimensions
+# ---------------------------------------------------------------------------
+POSE_LANDMARKS = 33
+HAND_LANDMARKS = 21
+
+# Full MediaPipe face mesh count (478 points). Kept for reference and for the
+# batch-conversion script that remaps old 1692-dim .npy files.
+FACE_LANDMARKS_FULL = 478
+
+# ---------------------------------------------------------------------------
+# Reduced face-landmark subset -- linguistically relevant regions only.
+#
+# Indices refer to MediaPipe FaceMesh point IDs (0-477).
+# Grouped by function:
+#   Lips outer  (20): mouth shape / mouthings
+#   Lips inner  (20): lip rounding, aperture
+#   R eyebrow   ( 5): grammatical markers (raised / furrowed)
+#   L eyebrow   ( 5): same
+#   R eye        ( 8): eye widening / squinting
+#   L eye        ( 8): same
+#   Iris        (10): gaze direction  (468-477)
+#   Nose         ( 3): spatial reference anchor
+#   Chin         ( 4): jaw opening
+# Total: 83 landmarks x 3 (x, y, z) = 249 face features
+# ---------------------------------------------------------------------------
+FACE_LANDMARK_INDICES: tuple[int, ...] = tuple(sorted((
+    # Lips -- outer contour
+    61, 146, 91, 181, 84, 17, 314, 405, 321, 375,
+    291, 409, 270, 269, 267, 0, 37, 39, 40, 185,
+    # Lips -- inner contour
+    78, 95, 88, 178, 87, 14, 317, 402, 318, 324,
+    308, 415, 310, 311, 312, 13, 82, 81, 80, 191,
+    # Right eyebrow
+    46, 53, 52, 65, 55,
+    # Left eyebrow
+    276, 283, 282, 295, 285,
+    # Right eye contour
+    33, 133, 157, 158, 159, 160, 144, 145,
+    # Left eye contour
+    263, 362, 384, 385, 386, 387, 373, 374,
+    # Iris (right 468-472, left 473-477)
+    468, 469, 470, 471, 472, 473, 474, 475, 476, 477,
+    # Nose bridge + tip
+    1, 4, 5,
+    # Chin
+    152, 175, 199, 200,
+)))
+
+FACE_LANDMARKS = len(FACE_LANDMARK_INDICES)  # 83
+
+# Feature vector dimension:
+# - Pose:       33 points x 4 features (x, y, z, visibility) = 132
+# - Face:       83 points x 3 features (x, y, z)             = 249
+# - Left hand:  21 points x 3 features (x, y, z)             =  63
+# - Right hand: 21 points x 3 features (x, y, z)             =  63
+# Total: 132 + 249 + 63 + 63 = 507 features per frame
+FEATURE_DIM = POSE_LANDMARKS * 4 + FACE_LANDMARKS * 3 + HAND_LANDMARKS * 3 * 2  # 507
+
+# Byte offsets for each landmark group within the 507-dim vector (used by
+# dataset/interpolation.py and dataset/augmentation.py).
+POSE_SLICE = slice(0, 132)
+FACE_SLICE = slice(132, 381)
+LEFT_HAND_SLICE = slice(381, 444)
+RIGHT_HAND_SLICE = slice(444, 507)
+
+
+# ---------------------------------------------------------------------------
+# Training / data configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TrainConfig:
+    """Mutable training hyper-parameters. Create via ``TrainConfig.full()``
+    or ``TrainConfig.test()`` for a quick smoke-test run."""
+
+    # Dataset selection (registry key: "bosphorus", "autsl", ...)
+    dataset: str = "bosphorus"
+
+    # Class selection
+    classes_to_process: list[str] = field(default_factory=list)
+
+    # Sequence handling
+    max_sequence_length: int = 150
+    min_sequence_length: int = 10
+    # Strategy for sequences longer than max_sequence_length:
+    #   "truncate"       -- keep first max_sequence_length frames (default;
+    #                      preserves native frame rate / temporal density)
+    #   "uniform_sample" -- evenly sample max_sequence_length frames across
+    #                      the full sequence so no temporal region is lost
+    #                      (better for attention models; can hurt RNNs that
+    #                      depend on smooth frame-to-frame dynamics)
+    sequence_handling: str = "truncate"
+
+    # Training
+    batch_size: int = 64
+    epochs: int = 300
+    learning_rate: float = 5e-4
+    grad_clip_norm: float = 1.0  # max gradient norm (0 to disable)
+    label_smoothing: float = 0.1  # label smoothing for CrossEntropyLoss (0 to disable)
+
+    # Early stopping (0 to disable)
+    early_stopping_patience: int = 35  # stop if val acc doesn't improve for N epochs
+    min_epochs: int = 250  # don't allow early stopping before this epoch
+
+    # Validation frequency
+    val_every: int = 5  # validate every N epochs
+
+    # LR scheduling
+    # - "onecycle": OneCycleLR stepped every batch (recommended default)
+    # - "cosine_warm_restarts": Linear warmup (epoch-stepped) + CosineAnnealingWarmRestarts
+    # - "plateau": ReduceLROnPlateau (legacy)
+    # - "none": fixed learning rate
+    lr_scheduler: str = "onecycle"
+
+    # Warmup (used for cosine_warm_restarts; OneCycle uses pct_start instead)
+    warmup_epochs: int = 5
+    warmup_start_factor: float = 0.1
+
+    # OneCycleLR params
+    # If None, max_lr will be derived from learning_rate at runtime.
+    onecycle_max_lr: float | None = None
+    onecycle_div_factor: float = 25.0
+    onecycle_final_div_factor: float = 1e4
+
+    # CosineAnnealingWarmRestarts params
+    cosine_t0: int = 10
+    cosine_t_mult: int = 2
+    cosine_eta_min: float = 1e-6
+
+    # Data handling
+    use_class_weights: bool = True
+    use_weighted_sampling: bool = False
+    normalize_features: bool = True
+    num_workers: int = 4
+    augment_train: bool = True  # apply data augmentation to training set
+
+    # Split configuration
+    split_mode: str = "signer"   # "signer" or "random"
+    val_split: float = 0.15     # used only in random mode
+    test_split: float = 0.15    # used only in random mode
+
+    # Model architecture
+    # One of the keys in models.MODEL_REGISTRY (e.g. "gru")
+    model_arch: str = "gru"
+
+    # Model size override (None = auto-detect from num_classes)
+    # Set to "small", "large", or "xlarge" to force a specific size preset.
+    model_size_override: str | None = None
+
+    # Dropout probability (None = auto-select based on model_size).
+    # Defaults: small/large -> 0.4, xlarge -> 0.2 (applied in evaluation/train.py).
+    dropout: float | None = None
+
+    # Extraction
+    apply_interpolation: bool = True
+
+    # ------------------------------------------------------------------
+    # Dataset info helper
+    # ------------------------------------------------------------------
+    @property
+    def dataset_info(self) -> "DatasetInfo":
+        """Return the :class:`DatasetInfo` instance for the selected dataset."""
+        from .dataset.registry import get_dataset_info
+        return get_dataset_info(self.dataset, BASE_DIR)
+
+    @staticmethod
+    def _all_sign_classes(dataset: str = "bosphorus") -> list[str]:
+        """Get all sign class names for the given dataset.
+
+        Returns an empty list if the dataset directory / label file doesn't exist.
+        """
+        from .dataset.registry import get_dataset_info
+        try:
+            info = get_dataset_info(dataset, BASE_DIR)
+            return info.class_names()
+        except Exception:
+            return []
+
+    @classmethod
+    def full(cls, dataset: str = "bosphorus") -> "TrainConfig":
+        """Full training configuration for the given dataset."""
+        return cls(
+            dataset=dataset,
+            classes_to_process=cls._all_sign_classes(dataset),
+            max_sequence_length=150,
+            batch_size=64,
+            epochs=300,
+            learning_rate=5e-4,
+            lr_scheduler="onecycle",
+            warmup_epochs=10,
+        )
+
+    @classmethod
+    def test(cls, n_classes: int = 10, dataset: str = "bosphorus") -> "TrainConfig":
+        """Quick smoke-test configuration."""
+        all_classes = cls._all_sign_classes(dataset)
+        return cls(
+            dataset=dataset,
+            classes_to_process=all_classes[:n_classes],
+            max_sequence_length=100,
+            batch_size=32,
+            epochs=100,
+            learning_rate=1e-3,
+            lr_scheduler="onecycle",
+            warmup_epochs=5,
+        )
+
+    @property
+    def num_classes(self) -> int:
+        """Return the total number of sign classes to train on."""
+        return len(self.classes_to_process)
+
+    @property
+    def actions(self) -> np.ndarray:
+        """Return the list of sign class names as a numpy array."""
+        return np.array(self.classes_to_process)
+
+    @property
+    def model_size(self) -> str:
+        """Determine model size based on number of classes.
+
+        If ``model_size_override`` is set, that value is returned directly.
+        Otherwise: ``'small'`` for <=50 classes, ``'large'`` for >50.
+        """
+        if self.model_size_override is not None:
+            return self.model_size_override
+        return "small" if self.num_classes <= 50 else "large"

--- a/tsl_recognition/models/__init__.py
+++ b/tsl_recognition/models/__init__.py
@@ -1,0 +1,67 @@
+"""
+Model registry for the TSL recognition pipeline.
+
+Provides ``SignClassifier`` (shared base class), ``MODEL_REGISTRY``
+(name -> class mapping) and a ``build_model`` factory so the rest of the
+codebase never needs to import individual architecture classes directly.
+"""
+
+from __future__ import annotations
+
+import torch.nn as nn
+
+from .base import SignClassifier
+from .gru import ActionGRU
+
+# ---------------------------------------------------------------------------
+# Registry: short CLI name  ->  model class
+# ---------------------------------------------------------------------------
+MODEL_REGISTRY: dict[str, type[nn.Module]] = {
+    "gru": ActionGRU,
+}
+
+
+def build_model(
+    arch: str,
+    input_size: int,
+    num_classes: int,
+    model_size: str = "small",
+    dropout: float = 0.4,
+) -> nn.Module:
+    """Instantiate a model by its registry name.
+
+    Parameters
+    ----------
+    arch : str
+        Key in ``MODEL_REGISTRY`` (e.g. ``"gru"``).
+    input_size : int
+        Feature dimension per time-step.
+    num_classes : int
+        Number of output classes.
+    model_size : str
+        ``"small"``, ``"large"``, or ``"xlarge"`` preset.
+    dropout : float
+        Dropout probability.
+
+    Returns
+    -------
+    nn.Module
+        The constructed model, ready for ``.to(device)``.
+
+    Raises
+    ------
+    ValueError
+        If *arch* is not found in the registry.
+    """
+    if arch not in MODEL_REGISTRY:
+        available = ", ".join(sorted(MODEL_REGISTRY))
+        raise ValueError(
+            f"Unknown architecture '{arch}'. Available: {available}"
+        )
+    cls = MODEL_REGISTRY[arch]
+    return cls(
+        input_size=input_size,
+        num_classes=num_classes,
+        model_size=model_size,
+        dropout=dropout,
+    )

--- a/tsl_recognition/models/base.py
+++ b/tsl_recognition/models/base.py
@@ -1,0 +1,118 @@
+"""
+SignClassifier — shared base class for all sign language classifiers.
+
+Provides:
+    - ``SIZES`` class attribute (each subclass overrides with its own presets)
+    - ``_get_config(model_size)`` helper that falls back to ``"small"``
+    - ``_build_head(...)`` to construct the shared FC classification head
+    - ``_classify(x)`` to run the head
+    - Abstract ``_encode(x, lengths)`` that each subclass implements
+    - Concrete ``forward(x, lengths)`` that calls ``_encode`` then ``_classify``
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import ClassVar
+
+import torch
+import torch.nn as nn
+
+
+class SignClassifier(nn.Module, abc.ABC):
+    """Abstract base for sign language classifiers.
+
+    Subclasses must:
+      1. Override ``SIZES`` with their own architecture presets.
+      2. Build encoder layers in ``__init__`` and call
+         ``self.head = self._build_head(...)`` to create the shared FC head.
+      3. Implement ``_encode(x, lengths)`` returning a ``(batch, features)``
+         tensor that feeds into the classification head.
+    """
+
+    SIZES: ClassVar[dict[str, dict]] = {}
+
+    def __init__(self, model_size: str = "small") -> None:
+        super().__init__()
+        self.model_size = model_size
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _get_config(cls, model_size: str) -> dict:
+        """Return the config dict for *model_size*, falling back to ``"small"``."""
+        return cls.SIZES.get(model_size, cls.SIZES["small"])
+
+    @staticmethod
+    def _build_head(
+        in_features: int,
+        fc_sizes: list[int],
+        num_classes: int,
+        dropout: float,
+    ) -> nn.Sequential:
+        """Build the shared FC classification head.
+
+        Architecture::
+
+            fc1 → bn1 → relu → drop → fc2 → bn2 → relu → drop → fc3
+        """
+        return nn.Sequential(
+            nn.Linear(in_features, fc_sizes[0]),
+            nn.BatchNorm1d(fc_sizes[0]),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(fc_sizes[0], fc_sizes[1]),
+            nn.BatchNorm1d(fc_sizes[1]),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(fc_sizes[1], num_classes),
+        )
+
+    # ------------------------------------------------------------------
+    # Forward pipeline
+    # ------------------------------------------------------------------
+
+    def _classify(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the classification head on encoder output."""
+        return self.head(x)
+
+    @abc.abstractmethod
+    def _encode(
+        self, x: torch.Tensor, lengths: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Encode an input sequence to a fixed-size representation.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(batch, seq_len, features)``.
+        lengths : torch.Tensor, optional
+            Actual (non-padded) sequence lengths, shape ``(batch,)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Encoded representation of shape ``(batch, encoder_out_features)``.
+        """
+        ...
+
+    def forward(
+        self, x: torch.Tensor, lengths: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Forward pass: encode the sequence then classify.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(batch, seq_len, features)``.
+        lengths : torch.Tensor, optional
+            Actual (non-padded) sequence lengths, shape ``(batch,)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Logits of shape ``(batch, num_classes)``.
+        """
+        return self._classify(self._encode(x, lengths))

--- a/tsl_recognition/models/gru.py
+++ b/tsl_recognition/models/gru.py
@@ -1,0 +1,69 @@
+"""
+ActionGRU — GRU-based sign language classifier.
+
+GRU cells have fewer gates than LSTM (reset + update vs. input/forget/output),
+making them lighter and potentially faster to train while retaining competitive
+accuracy on sequence tasks.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from .base import SignClassifier
+
+
+class ActionGRU(SignClassifier):
+    """GRU classifier with 4–6 stacked layers.
+
+    Uses the same SignClassifier interface with GRU cells. At least four
+    layers are used to give the model sufficient depth.
+    """
+
+    SIZES = {
+        "small":  {"gru_hidden": 256,  "gru_layers": 4, "fc": [512, 256]},
+        "large":  {"gru_hidden": 512,  "gru_layers": 5, "fc": [1024, 512]},
+        "xlarge": {"gru_hidden": 1024, "gru_layers": 6, "fc": [2048, 1024]},
+    }
+
+    def __init__(
+        self,
+        input_size: int,
+        num_classes: int,
+        model_size: str = "small",
+        dropout: float = 0.4,
+    ):
+        super().__init__(model_size=model_size)
+        cfg = self._get_config(model_size)
+
+        self.gru = nn.GRU(
+            input_size=input_size,
+            hidden_size=cfg["gru_hidden"],
+            num_layers=cfg["gru_layers"],
+            batch_first=True,
+            dropout=dropout if cfg["gru_layers"] > 1 else 0,
+            bidirectional=False,
+        )
+
+        self.head = self._build_head(
+            cfg["gru_hidden"], cfg["fc"], num_classes, dropout,
+        )
+
+    def _encode(
+        self, x: torch.Tensor, lengths: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Encode via GRU, returning the hidden state at the last real frame."""
+        if lengths is not None:
+            packed = nn.utils.rnn.pack_padded_sequence(
+                x, lengths.cpu().clamp(min=1), batch_first=True, enforce_sorted=False,
+            )
+            packed_out, _ = self.gru(packed)
+            gru_out, _ = nn.utils.rnn.pad_packed_sequence(packed_out, batch_first=True)
+        else:
+            gru_out, _ = self.gru(x)
+
+        if lengths is not None:
+            batch_idx = torch.arange(x.size(0), device=x.device)
+            return gru_out[batch_idx, lengths - 1, :]
+        return gru_out[:, -1, :]


### PR DESCRIPTION
## What does this PR do?

Ports \`config.py\` and \`models/\` from the SoziaSign source repo into \`tsl_recognition\`. Removed legacy path constants and the import-time \`set_seed()\` call. Added slice constants for downstream use in the dataset pipeline. Models carry over unchanged.

## Which pipeline does it touch?
- [x] TSL Recognition
- [ ] Gloss-to-Text
- [ ] Shared scripts/configs

## Experiment details (if applicable)
N/A - no training run.

## Checklist
- [x] Follows commit convention (\`<type>(<scope>): <description>\`)
- [x] Training configs are reproducible (seeds, hyperparams documented)
- [x] No large binary files committed directly (use LFS or external storage)

Closes #1