### PR TITLE
feat(recognition): port training, evaluation, and CLI

### DIFF
--- a/tsl_recognition/__main__.py
+++ b/tsl_recognition/__main__.py
@@ -1,0 +1,10 @@
+"""Allow ``python -m tsl_recognition <command>`` from the project root.
+
+    python -m tsl_recognition extract --test
+    python -m tsl_recognition train
+    python -m tsl_recognition infer --mode motion
+    python -m tsl_recognition validate
+"""
+from .cli import main
+
+main()

--- a/tsl_recognition/cli.py
+++ b/tsl_recognition/cli.py
@@ -1,0 +1,213 @@
+"""
+CLI entry point for the Sign Language Recognition pipeline.
+
+Usage::
+
+    # From the project root directory:
+    python -m tsl_recognition split                                    # BosphorusSign22k signer split
+    python -m tsl_recognition split --dataset autsl                    # AUTSL predefined split
+    python -m tsl_recognition split --split-mode random                # stratified random split
+    python -m tsl_recognition extract                                  # extract keypoints (Bosphorus)
+    python -m tsl_recognition extract --dataset autsl                  # extract keypoints (AUTSL)
+    python -m tsl_recognition train                                    # train with default GRU
+    python -m tsl_recognition train --dataset autsl                    # train GRU on AUTSL
+    python -m tsl_recognition evaluate                                 # re-evaluate latest run
+    python -m tsl_recognition evaluate --all                           # re-evaluate ALL past runs
+    python -m tsl_recognition infer --mode motion                      # real-time inference
+    python -m tsl_recognition validate                                 # validate inference pipeline
+    python -m tsl_recognition validate --run-dir trained-models/run_*  # validate specific run
+    python -m tsl_recognition infer --mode video --video path/to/video.mp4
+
+Add ``--test`` to any subcommand for a quick 10-class smoke test.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from .config import TrainConfig
+from .dataset.registry import DATASET_CHOICES
+
+
+def _make_config(args) -> TrainConfig:
+    """Build a TrainConfig from parsed CLI arguments."""
+    dataset = getattr(args, "dataset", "bosphorus") or "bosphorus"
+    if getattr(args, "test", False):
+        cfg = TrainConfig.test(dataset=dataset)
+    else:
+        cfg = TrainConfig.full(dataset=dataset)
+    return cfg
+
+
+def cmd_split(args):
+    """Execute the split generation command."""
+    from .dataset.split import generate_split
+    cfg = _make_config(args)
+    if args.split_mode is not None:
+        cfg.split_mode = args.split_mode
+    else:
+        cfg.split_mode = cfg.dataset_info.default_split_mode
+    generate_split(cfg)
+
+
+def cmd_extract(args):
+    """Execute the keypoint extraction command."""
+    from .extraction import run_extraction
+    cfg = _make_config(args)
+    run_extraction(cfg, num_workers=args.num_workers)
+
+
+def cmd_train(args):
+    """Execute the model training command."""
+    from .evaluation.train import train
+    cfg = _make_config(args)
+    if hasattr(args, "split_mode") and args.split_mode:
+        cfg.split_mode = args.split_mode
+    if hasattr(args, "model") and args.model:
+        cfg.model_arch = args.model
+    if args.label_smoothing is not None:
+        cfg.label_smoothing = args.label_smoothing
+    if hasattr(args, "model_size") and args.model_size:
+        cfg.model_size_override = args.model_size
+    train(cfg)
+
+
+def cmd_infer(args):
+    """Execute the inference command."""
+    from .evaluation.inference import InferenceMode, run_inference
+    mode_map = {
+        "trigger": InferenceMode.TRIGGER,
+        "motion": InferenceMode.MOTION,
+        "continuous": InferenceMode.CONTINUOUS,
+        "video": InferenceMode.VIDEO_FILE,
+    }
+    cfg = _make_config(args)
+    run_inference(
+        mode=mode_map[args.mode],
+        cfg=cfg,
+        video_path=args.video,
+        run_dir=getattr(args, "run_dir", None),
+        show_landmarks=not args.no_landmarks,
+        headless=args.headless,
+    )
+
+
+def cmd_evaluate(args):
+    """Re-evaluate a saved model on the test set (top-1 & top-5 accuracy)."""
+    from .evaluation.evaluate import evaluate_all, evaluate_run
+    dataset = getattr(args, "dataset", "bosphorus") or "bosphorus"
+    if args.all:
+        evaluate_all(dataset=dataset)
+    else:
+        evaluate_run(run_dir=getattr(args, "run_dir", None), dataset=dataset)
+
+
+def cmd_validate(args):
+    """Execute the validation command."""
+    from .evaluation.validate import run_validation
+    dataset = getattr(args, "dataset", "bosphorus") or "bosphorus"
+    run_validation(run_dir=getattr(args, "run_dir", None), n_samples=args.samples, dataset=dataset)
+
+
+def main():
+    """Main CLI entry point for the Sign Language Recognition pipeline."""
+    parser = argparse.ArgumentParser(
+        prog="tsl_recognition",
+        description="Sign Language Recognition pipeline",
+    )
+
+    shared_parent = argparse.ArgumentParser(add_help=False)
+    shared_parent.add_argument(
+        "--test", action="store_true",
+        help="Use 10-class test config instead of full training",
+    )
+    shared_parent.add_argument(
+        "--dataset", choices=DATASET_CHOICES, default="bosphorus",
+        help="Dataset to use (default: bosphorus)",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # split
+    p_split = sub.add_parser("split", parents=[shared_parent],
+                              help="Generate train/val/test split manifests")
+    p_split.add_argument(
+        "--split-mode", choices=["signer", "random", "predefined"], default=None,
+        help="Split strategy (default: dataset-specific)",
+    )
+
+    # extract
+    p_extract = sub.add_parser("extract", parents=[shared_parent],
+                               help="Extract keypoints from sign-language videos")
+    p_extract.add_argument(
+        "--num-workers", type=int, default=1,
+        help="Number of parallel worker processes (default: 1 = sequential)",
+    )
+
+    # train
+    p_train = sub.add_parser("train", parents=[shared_parent],
+                              help="Train a sign language recognition model")
+    p_train.add_argument(
+        "--model",
+        choices=["gru"],
+        default=None,
+        help="Model architecture (default: gru)",
+    )
+    p_train.add_argument(
+        "--split-mode", choices=["signer", "random", "predefined"], default=None,
+        help="Override split mode for scaler selection",
+    )
+    p_train.add_argument(
+        "--label-smoothing", type=float, default=None,
+        help="Label smoothing value (default: 0.1; use 0 to disable)",
+    )
+    p_train.add_argument(
+        "--model-size", choices=["small", "large", "xlarge"], default=None,
+        help="Override model size preset (default: auto-detect from class count)",
+    )
+
+    # infer
+    p_infer = sub.add_parser("infer", parents=[shared_parent],
+                              help="Run real-time or video inference")
+    p_infer.add_argument(
+        "--mode", choices=["trigger", "motion", "continuous", "video"],
+        default="motion", help="Inference mode (default: motion)",
+    )
+    p_infer.add_argument("--video", type=str, default=None, help="Video path for video mode")
+    p_infer.add_argument("--run-dir", type=str, default=None,
+                          help="Path to a run_* directory (default: latest)")
+    p_infer.add_argument("--no-landmarks", action="store_true", help="Hide landmark overlay")
+    p_infer.add_argument("--headless", action="store_true",
+                          help="Skip GUI window (auto-detected when no display)")
+
+    # evaluate
+    p_eval = sub.add_parser("evaluate", parents=[shared_parent],
+                             help="Re-evaluate a saved model on the test set")
+    p_eval.add_argument("--run-dir", type=str, default=None,
+                         help="Path to a run_* directory (default: latest)")
+    p_eval.add_argument("--all", action="store_true",
+                         help="Re-evaluate ALL run_* directories")
+
+    # validate
+    p_val = sub.add_parser("validate", parents=[shared_parent],
+                            help="Validate inference vs training pipeline")
+    p_val.add_argument("--samples", type=int, default=100,
+                       help="Number of samples to validate")
+    p_val.add_argument("--run-dir", type=str, default=None,
+                       help="Path to a run_* directory (default: latest)")
+
+    args = parser.parse_args()
+
+    dispatch = {
+        "split": cmd_split,
+        "extract": cmd_extract,
+        "train": cmd_train,
+        "evaluate": cmd_evaluate,
+        "infer": cmd_infer,
+        "validate": cmd_validate,
+    }
+    dispatch[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tsl_recognition/evaluation/__init__.py
+++ b/tsl_recognition/evaluation/__init__.py
@@ -1,0 +1,10 @@
+"""
+Evaluation subpackage — training, inference, and validation for the TSL recognition pipeline.
+
+Modules:
+    train         - Training loop, LR scheduling, checkpointing, metric logging
+    inference     - Real-time and video-file inference (TRIGGER/MOTION/CONTINUOUS/VIDEO_FILE)
+    evaluate      - Re-evaluate a saved model on the held-out test set
+    validate      - Check that inference preprocessing matches training preprocessing
+    visualization - MediaPipe landmark drawing and inference HUD overlay
+"""

--- a/tsl_recognition/evaluation/evaluate.py
+++ b/tsl_recognition/evaluation/evaluate.py
@@ -1,0 +1,194 @@
+"""
+Re-evaluate a saved model on the held-out test set.
+
+Loads a trained model from any ``run_*`` directory and computes top-1 and
+top-5 accuracy, per-class metrics, and a confusion matrix — without
+retraining.  The updated ``scores.json`` is written back to the run
+directory.
+
+Usage::
+
+    python -m tsl_recognition evaluate                                # latest run
+    python -m tsl_recognition evaluate --run-dir trained-models/run_* # specific run
+    python -m tsl_recognition evaluate --all                          # all runs
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+from sklearn.metrics import accuracy_score, multilabel_confusion_matrix
+from torch.utils.data import DataLoader
+
+from ..config import DEVICE, MODELS_DIR, TrainConfig
+from ..dataset.loader import LazySignDataset
+from .inference import _find_latest_run, _load_run
+from .train import _save_scores, batch_top_k_accuracy
+
+
+def _load_test_files(
+    split_dir: Path,
+    actions: np.ndarray,
+) -> list[tuple[str, int, int]]:
+    """Load test-split file list from the persisted manifest."""
+    manifest = split_dir / "test.json"
+    if not manifest.exists():
+        raise FileNotFoundError(
+            f"No test manifest at {manifest}. Run `python -m tsl_recognition split` first."
+        )
+    with open(manifest) as f:
+        entries = json.load(f)
+
+    label_map = {name: idx for idx, name in enumerate(actions)}
+    allowed = set(label_map)
+    files: list[tuple[str, int, int]] = []
+    for e in entries:
+        cls = e.get("class_name")
+        if cls not in allowed:
+            continue
+        files.append((e["path"], label_map[cls], int(e["num_frames"])))
+    return files
+
+
+def evaluate_run(
+    run_dir: Path | str | None = None,
+    dataset: str = "bosphorus",
+) -> dict:
+    """Re-evaluate a saved model on the full test set.
+
+    Parameters
+    ----------
+    run_dir : Path | str | None
+        Path to a ``run_*`` directory produced by ``train.py``.  If *None*,
+        the most recent run directory under ``MODELS_DIR`` is used.
+    dataset : str
+        Dataset name used to locate the split directory.
+
+    Returns
+    -------
+    dict
+        ``test_accuracy``, ``test_top5_accuracy``, ``best_val_accuracy``,
+        ``best_val_top5_accuracy``, ``num_classes``, ``num_test_samples``.
+    """
+    rd = Path(run_dir) if run_dir is not None else _find_latest_run(MODELS_DIR)
+    run_data = _load_run(rd)
+    model = run_data["model"]
+    scaler = run_data["scaler"]
+    actions = run_data["actions"]
+    max_len = run_data["max_len"]
+    seq_handling = run_data["sequence_handling"]
+    feature_dim = run_data["feature_dim"]
+    num_classes = len(actions)
+
+    scores_path = rd / "scores.json"
+    best_val_acc = 0.0
+    best_val_acc5 = 0.0
+    if scores_path.exists():
+        with open(scores_path) as f:
+            old_scores = json.load(f)
+        best_val_acc = old_scores.get("best_val_accuracy", 0.0)
+        best_val_acc5 = old_scores.get("best_val_top5_accuracy", 0.0)
+
+    ds_info = TrainConfig(dataset=dataset).dataset_info
+    test_files = _load_test_files(ds_info.split_dir, actions)
+    if not test_files:
+        raise RuntimeError("No test files found in split manifest matching run classes.")
+
+    test_ds = LazySignDataset(
+        file_info_list=test_files,
+        max_seq_len=max_len,
+        feature_dim=feature_dim,
+        scaler=scaler,
+        augment=False,
+        sequence_handling=seq_handling,
+    )
+    test_loader = DataLoader(
+        test_ds,
+        batch_size=64,
+        shuffle=False,
+        num_workers=4,
+        pin_memory=True,
+    )
+
+    print(f"\nEvaluating on {len(test_files)} test samples...")
+    print(f"{'='*60}")
+
+    all_logits_list, all_true = [], []
+    with torch.no_grad():
+        for xb, yb, lengths in test_loader:
+            logits = model(xb.to(DEVICE), lengths=lengths.to(DEVICE))
+            all_logits_list.append(logits.cpu())
+            all_true.extend(yb.numpy().tolist())
+
+    all_logits = torch.cat(all_logits_list, dim=0)
+    all_targets = torch.tensor(all_true, dtype=torch.long)
+    all_preds = torch.argmax(all_logits, dim=1).numpy().tolist()
+
+    all_labels = list(range(num_classes))
+    test_acc = accuracy_score(all_true, all_preds)
+    test_acc5 = batch_top_k_accuracy(all_logits, all_targets, k=5)
+    cm = multilabel_confusion_matrix(all_true, all_preds, labels=all_labels)
+
+    print(f"Test Accuracy (top-1): {test_acc:.4f}")
+    print(f"Test Accuracy (top-5): {test_acc5:.4f}")
+    print(f"Test samples:          {len(test_files)}")
+    print(f"Num classes:           {num_classes}")
+
+    _save_scores(rd, test_acc, test_acc5, best_val_acc, best_val_acc5, cm, actions)
+    print(f"\nscores.json updated in: {rd}")
+
+    return {
+        "run_dir": rd,
+        "test_accuracy": test_acc,
+        "test_top5_accuracy": test_acc5,
+        "best_val_accuracy": best_val_acc,
+        "best_val_top5_accuracy": best_val_acc5,
+        "num_classes": num_classes,
+        "num_test_samples": len(test_files),
+    }
+
+
+def evaluate_all(dataset: str = "bosphorus") -> list[dict]:
+    """Re-evaluate every ``run_*`` directory under ``MODELS_DIR``.
+
+    Returns
+    -------
+    list[dict]
+        One result dict per run (same format as ``evaluate_run``).
+    """
+    runs = sorted(MODELS_DIR.glob("run_*"))
+    if not runs:
+        raise FileNotFoundError(
+            f"No run directories found in {MODELS_DIR}. Train a model first."
+        )
+
+    results = []
+    for rd in runs:
+        print(f"\n{'='*60}")
+        print(f"RE-EVALUATING: {rd.name}")
+        print(f"{'='*60}")
+        try:
+            result = evaluate_run(rd, dataset=dataset)
+            results.append(result)
+        except Exception as e:
+            print(f"  SKIPPED ({e})")
+            continue
+
+    if results:
+        print(f"\n\n{'='*80}")
+        print("RE-EVALUATION SUMMARY")
+        print(f"{'='*80}")
+        print(f"{'Run':<45} {'Top-1':>8} {'Top-5':>8} {'Classes':>8}")
+        print(f"{'-'*45} {'-'*8} {'-'*8} {'-'*8}")
+        for r in results:
+            name = r["run_dir"].name
+            print(
+                f"{name:<45} "
+                f"{r['test_accuracy']:>7.4f} "
+                f"{r['test_top5_accuracy']:>7.4f} "
+                f"{r['num_classes']:>8}"
+            )
+    return results

--- a/tsl_recognition/evaluation/inference.py
+++ b/tsl_recognition/evaluation/inference.py
@@ -1,0 +1,531 @@
+"""
+Real-time and video-file inference for sign language recognition.
+
+Supports four modes via ``InferenceMode``:
+    TRIGGER     - press SPACE to start/stop recording
+    MOTION      - auto-detect sign boundaries via hand motion
+    CONTINUOUS  - sliding window prediction every N frames
+    VIDEO_FILE  - collect all frames from video, predict at end
+
+Usage::
+
+    python -m tsl_recognition infer --mode motion
+    python -m tsl_recognition infer --mode video --video path/to/video.mp4
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pickle
+import sys
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from pathlib import Path
+from typing import Optional
+
+import cv2
+import numpy as np
+import torch
+
+from ..config import (
+    DEVICE,
+    FACE_LANDMARKS,
+    HAND_LANDMARKS,
+    MODELS_DIR,
+    MP_MODEL_DIR,
+    POSE_LANDMARKS,
+    TrainConfig,
+)
+from ..dataset.interpolation import EXPECTED_DIM, interpolate_missing_keypoints
+from ..extraction.landmarks import create_landmarkers, detect_landmarks, extract_keypoints
+from ..models import build_model
+from .visualization import draw_results, draw_status_bar
+
+
+def _has_display() -> bool:
+    """Return True if a GUI display is available for cv2.imshow."""
+    if sys.platform == "win32":
+        return True
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+class InferenceMode(Enum):
+    TRIGGER = auto()
+    MOTION = auto()
+    CONTINUOUS = auto()
+    VIDEO_FILE = auto()
+
+
+@dataclass
+class SignRecorder:
+    """Manages sign recording state with motion detection.
+
+    Attributes
+    ----------
+    frames : list
+        Collected keypoint frames for the current sign.
+    is_recording : bool
+        Whether we're currently recording a sign.
+    motion_history : deque
+        Recent hand motion velocities (for smoothing).
+    low_motion_count : int
+        Number of consecutive frames with low motion.
+    last_hand_positions : np.ndarray | None
+        Hand positions from previous frame (for velocity calculation).
+    """
+    frames: list = field(default_factory=list)
+    is_recording: bool = False
+    motion_history: deque = field(default_factory=lambda: deque(maxlen=15))
+    low_motion_count: int = 0
+    last_hand_positions: Optional[np.ndarray] = None
+
+    def reset(self):
+        """Reset the recorder state for a new sign."""
+        self.frames = []
+        self.is_recording = False
+        self.low_motion_count = 0
+        self.last_hand_positions = None
+
+    def compute_hand_motion(self, keypoints: np.ndarray) -> float:
+        """Calculate hand motion velocity from keypoints.
+
+        Parameters
+        ----------
+        keypoints : np.ndarray
+            Flattened keypoint vector (507 dimensions).
+
+        Returns
+        -------
+        float
+            Hand motion velocity (Euclidean distance moved since last frame).
+        """
+        lstart = POSE_LANDMARKS * 4 + FACE_LANDMARKS * 3
+        rstart = lstart + HAND_LANDMARKS * 3
+
+        hand_len = HAND_LANDMARKS * 3
+        lh = keypoints[lstart:lstart + hand_len].reshape(-1, 3)[:, :2]
+        rh = keypoints[rstart:rstart + hand_len].reshape(-1, 3)[:, :2]
+
+        positions = []
+        if np.any(np.abs(lh) > 1e-6):
+            positions.append(np.mean(lh, axis=0))
+        if np.any(np.abs(rh) > 1e-6):
+            positions.append(np.mean(rh, axis=0))
+
+        if not positions:
+            return 0.0
+
+        cur = np.array(positions)
+
+        if self.last_hand_positions is None or len(cur) != len(self.last_hand_positions):
+            self.last_hand_positions = cur
+            return 0.0
+
+        vel = float(np.mean(np.linalg.norm(cur - self.last_hand_positions, axis=1)))
+        self.last_hand_positions = cur
+        self.motion_history.append(vel)
+        return vel
+
+    def get_smoothed_motion(self) -> float:
+        """Get temporally smoothed motion value.
+
+        Returns
+        -------
+        float
+            Average motion over recent frames.
+        """
+        return float(np.mean(list(self.motion_history))) if self.motion_history else 0.0
+
+
+def preprocess_sequence(
+    frames,
+    scaler,
+    max_len,
+    normalize=True,
+    apply_interpolation=True,
+    sequence_handling="truncate",
+):
+    """Preprocess collected keypoints identically to training pipeline.
+
+    Parameters
+    ----------
+    frames : list[np.ndarray]
+        List of keypoint arrays (one per frame).
+    scaler : StandardScaler | None
+        Fitted scaler for normalization.
+    max_len : int
+        Maximum sequence length (truncate/pad to this).
+    normalize : bool, optional
+        Whether to apply normalization (default: True).
+    apply_interpolation : bool, optional
+        Whether to interpolate missing landmarks (default: True).
+    sequence_handling : str, optional
+        Strategy for sequences longer than *max_len*:
+        ``"truncate"`` keeps the first *max_len* frames (default);
+        ``"uniform_sample"`` evenly samples *max_len* frames across the
+        full sequence (matches ``LazySignDataset`` training behaviour).
+
+    Returns
+    -------
+    tuple[np.ndarray, int]
+        - Preprocessed keypoint array of shape (max_len, feature_dim).
+        - Actual (non-padded) sequence length.
+    """
+    kp = np.array(frames, dtype=np.float32)
+    n = len(kp)
+
+    if apply_interpolation and kp.shape[1] == EXPECTED_DIM:
+        try:
+            kp = interpolate_missing_keypoints(kp).astype(np.float32)
+        except Exception:
+            pass
+
+    if normalize and scaler is not None:
+        kp = scaler.transform(kp)
+
+    if n > max_len:
+        if sequence_handling == "uniform_sample":
+            indices = np.linspace(0, n - 1, max_len).round().astype(int)
+            kp = kp[indices]
+        else:
+            kp = kp[:max_len]
+        n = max_len
+
+    actual_length = n
+
+    if n < max_len:
+        kp = np.vstack([kp, np.zeros((max_len - n, kp.shape[1]), dtype=np.float32)])
+
+    return kp, actual_length
+
+
+def predict_sign(model, kp_array, actual_length, device, actions, top_k=5):
+    """Predict sign class from preprocessed keypoint sequence.
+
+    Parameters
+    ----------
+    model : nn.Module
+        Trained model (any architecture from the model registry).
+    kp_array : np.ndarray
+        Preprocessed keypoint sequence of shape (max_len, feature_dim).
+    actual_length : int
+        Number of real (non-padded) frames in *kp_array*.
+    device : torch.device
+        Device to run inference on (CPU/GPU).
+    actions : np.ndarray
+        Array of sign class names.
+    top_k : int, optional
+        Number of top predictions to return (default: 5).
+
+    Returns
+    -------
+    tuple[list, np.ndarray]
+        - List of (class_name, probability) tuples for top-k predictions
+        - Full probability distribution over all classes
+    """
+    x = torch.tensor(kp_array, dtype=torch.float32).unsqueeze(0).to(device)
+    lengths = torch.tensor([actual_length], dtype=torch.long).to(device)
+    with torch.no_grad():
+        probs = torch.softmax(model(x, lengths=lengths), dim=1).cpu().numpy()[0]
+    idx = np.argsort(probs)[::-1][:top_k]
+    return [(actions[i], float(probs[i])) for i in idx], probs
+
+
+def _find_latest_run(models_dir: Path) -> Path:
+    """Return the most recent ``run_*`` directory under *models_dir*.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no run directories exist.
+    """
+    runs = sorted(models_dir.glob("run_*"))
+    if not runs:
+        raise FileNotFoundError(
+            f"No run directories found in {models_dir}. Train a model first."
+        )
+    return runs[-1]
+
+
+def _load_run(run_dir: Path) -> dict:
+    """Load a trained model and its associated artefacts from a run directory.
+
+    All metadata is read from the ``config.json`` saved by ``train.py``, so
+    the correct architecture, scaler, and class list are always used.
+
+    The scaler is loaded from ``dataset_info.processed_dir`` (derived from the
+    dataset name stored in ``config.json``), not from a hardcoded path.
+
+    Parameters
+    ----------
+    run_dir : Path
+        Path to a ``run_*`` directory produced by ``train.py``.
+
+    Returns
+    -------
+    dict
+        Keys: ``model``, ``scaler``, ``actions``, ``max_len``,
+        ``sequence_handling``, ``normalize``, ``feature_dim``.
+    """
+    config_path = run_dir / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"No config.json in {run_dir}")
+    with open(config_path) as f:
+        meta = json.load(f)
+
+    model_arch: str = meta["model_arch"]
+    model_size: str = meta["model_size"]
+    feature_dim: int = int(meta["feature_dim"])
+    dropout: float = float(meta.get("dropout") or 0.4)
+    split_mode: str = meta.get("split_mode", "signer")
+    classes: list[str] = meta["classes_to_process"]
+    num_classes: int = len(classes)
+    max_len: int = int(meta["max_sequence_length"])
+    seq_handling: str = meta.get("sequence_handling", "truncate")
+    normalize: bool = bool(meta.get("normalize_features", True))
+    dataset_name: str = meta.get("dataset", "bosphorus")
+
+    print(f"Run directory : {run_dir}")
+    print(f"Architecture  : {model_arch} ({model_size})")
+    print(f"Classes       : {num_classes}")
+    print(f"Feature dim   : {feature_dim}")
+    print(f"Max seq len   : {max_len}")
+    print(f"Seq handling  : {seq_handling}")
+
+    scaler = None
+    if normalize:
+        processed_dir = TrainConfig(dataset=dataset_name).dataset_info.processed_dir
+        scaler_path = processed_dir / f"scaler_{split_mode}.pkl"
+        if scaler_path.exists():
+            with open(scaler_path, "rb") as f:
+                scaler = pickle.load(f)
+            print(f"Scaler loaded : {scaler_path.name}")
+        else:
+            print(f"WARNING: scaler not found at {scaler_path} — running without normalisation")
+
+    model = build_model(
+        arch=model_arch,
+        input_size=feature_dim,
+        num_classes=num_classes,
+        model_size=model_size,
+        dropout=dropout,
+    ).to(DEVICE)
+
+    ckpt_path = run_dir / "best_model.pt"
+    if not ckpt_path.exists():
+        raise FileNotFoundError(f"No best_model.pt in {run_dir}")
+    state_dict = torch.load(ckpt_path, map_location=DEVICE, weights_only=True)
+    model.load_state_dict(state_dict)
+    model.eval()
+    print(f"Checkpoint    : {ckpt_path.name}")
+
+    actions = np.array(classes)
+
+    return {
+        "model": model,
+        "scaler": scaler,
+        "actions": actions,
+        "max_len": max_len,
+        "sequence_handling": seq_handling,
+        "normalize": normalize,
+        "feature_dim": feature_dim,
+    }
+
+
+# ===================================================================
+# Main inference loop
+# ===================================================================
+def run_inference(
+    mode: InferenceMode = InferenceMode.MOTION,
+    cfg: TrainConfig | None = None,
+    video_path: Path | str | None = None,
+    run_dir: Path | str | None = None,
+    show_landmarks: bool = True,
+    top_k: int = 5,
+    motion_start: float = 0.015,
+    motion_end: float = 0.005,
+    motion_end_frames: int = 10,
+    min_sign_frames: int = 15,
+    continuous_every: int = 30,
+    normalize: bool = True,
+    headless: bool = False,
+) -> None:
+    """Run the inference loop (webcam or video file).
+
+    Parameters
+    ----------
+    run_dir : Path | str | None
+        Path to a ``run_*`` directory produced by ``train.py``.  If *None*,
+        the most recent run directory under ``MODELS_DIR`` is used.
+    headless : bool
+        If *True*, skip all cv2.imshow/waitKey calls.  Auto-detected when
+        not set explicitly and no DISPLAY / WAYLAND_DISPLAY env var is found.
+    """
+    if cfg is None:
+        cfg = TrainConfig.full()
+    show_gui = not headless and _has_display()
+    if not show_gui:
+        print("No display detected — running in headless mode (no GUI window)")
+
+    rd = Path(run_dir) if run_dir is not None else _find_latest_run(MODELS_DIR)
+    run_data = _load_run(rd)
+    model = run_data["model"]
+    scaler = run_data["scaler"]
+    actions = run_data["actions"]
+    max_len = run_data["max_len"]
+    seq_handling = run_data["sequence_handling"]
+    normalize = run_data["normalize"]
+
+    print(f"Feature normalization: {'ON' if normalize else 'OFF'}")
+    print(f"Inference mode: {mode.name}")
+
+    if mode == InferenceMode.VIDEO_FILE:
+        if not video_path:
+            raise ValueError("--video path is required for video mode")
+        vp = Path(video_path)
+        if not vp.exists():
+            raise FileNotFoundError(f"Video not found: {vp}")
+        cap = cv2.VideoCapture(str(vp))
+        print(f"Video: {vp}\nExpected class: {vp.parent.name}")
+    else:
+        vp = None
+        cap = cv2.VideoCapture(0, getattr(cv2, "CAP_V4L2", cv2.CAP_ANY))
+        cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
+        cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
+        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
+        cap.set(cv2.CAP_PROP_FPS, 30)
+        print("Webcam initialized")
+
+    rec = SignRecorder()
+    cur_preds = None
+    history: list[str] = []
+    fcount = 0
+    ts = 0
+    print(f"\n{'='*60}\nStarting inference loop...\n{'='*60}\n")
+
+    with create_landmarkers(MP_MODEL_DIR) as (face_lm, hand_lm, hand_crop_lm, pose_lm):
+        while cap.isOpened():
+            ret, frame = cap.read()
+            if not ret:
+                if mode == InferenceMode.VIDEO_FILE:
+                    break
+                continue
+            fcount += 1
+            if mode != InferenceMode.VIDEO_FILE:
+                frame = cv2.flip(frame, 1)
+            ts += 33
+            fr, hr, pr = detect_landmarks(frame, face_lm, hand_lm, hand_crop_lm, pose_lm, ts)
+            if show_landmarks:
+                frame = draw_results(frame, fr, hr, pr)
+            kp = extract_keypoints(fr, hr, pr)
+            kp = np.asarray(kp, dtype=np.float32).reshape(-1)
+            if kp.size < EXPECTED_DIM:
+                kp = np.pad(kp, (0, EXPECTED_DIM - kp.size))
+            elif kp.size > EXPECTED_DIM:
+                kp = kp[:EXPECTED_DIM]
+            dbg: dict = {}
+
+            if mode == InferenceMode.TRIGGER:
+                if rec.is_recording:
+                    rec.frames.append(kp)
+                    if len(rec.frames) >= max_len:
+                        arr, alen = preprocess_sequence(rec.frames, scaler, max_len, normalize, True, seq_handling)
+                        cur_preds, _ = predict_sign(model, arr, alen, DEVICE, actions, top_k)
+                        history.append(cur_preds[0][0])
+                        print(f"Prediction: {cur_preds[0][0]} ({cur_preds[0][1]*100:.1f}%)")
+                        rec.reset()
+
+            elif mode == InferenceMode.MOTION:
+                mot = rec.compute_hand_motion(kp)
+                sm = rec.get_smoothed_motion()
+                dbg["motion"] = mot
+                dbg["smoothed_motion"] = sm
+
+                if not rec.is_recording:
+                    if sm > motion_start:
+                        rec.is_recording = True
+                        rec.frames = [kp]
+                        rec.low_motion_count = 0
+                        print(f"Sign started (motion={sm:.4f})")
+                else:
+                    rec.frames.append(kp)
+
+                    if sm < motion_end:
+                        rec.low_motion_count += 1
+                    else:
+                        rec.low_motion_count = 0
+
+                    do_pred = False
+                    if rec.low_motion_count >= motion_end_frames and len(rec.frames) >= min_sign_frames:
+                        print(f"Sign ended (low motion for {motion_end_frames} frames)")
+                        do_pred = True
+                    elif len(rec.frames) >= max_len:
+                        print("Sign ended (max frames reached)")
+                        do_pred = True
+
+                    if do_pred:
+                        arr, alen = preprocess_sequence(rec.frames, scaler, max_len, normalize, True, seq_handling)
+                        cur_preds, _ = predict_sign(model, arr, alen, DEVICE, actions, top_k)
+                        history.append(cur_preds[0][0])
+                        print(f"Prediction ({len(rec.frames)} frames): {cur_preds[0][0]} ({cur_preds[0][1]*100:.1f}%)")
+                        for j, (c, p) in enumerate(cur_preds[:3]):
+                            print(f"  {j+1}. {c}: {p*100:.1f}%")
+                        rec.reset()
+
+            elif mode == InferenceMode.CONTINUOUS:
+                rec.frames.append(kp)
+                if len(rec.frames) >= max_len:
+                    rec.frames = rec.frames[-max_len:]
+                if fcount % continuous_every == 0 and len(rec.frames) >= min_sign_frames:
+                    arr, alen = preprocess_sequence(rec.frames, scaler, max_len, normalize, True, seq_handling)
+                    cur_preds, _ = predict_sign(model, arr, alen, DEVICE, actions, top_k)
+
+            elif mode == InferenceMode.VIDEO_FILE:
+                rec.frames.append(kp)
+
+            if show_gui:
+                frame = draw_status_bar(frame, rec, mode, cur_preds, dbg)
+                cv2.imshow("Sign Language Recognition", frame)
+            key = cv2.waitKey(10) & 0xFF if show_gui else 0xFF
+            if key == ord("q"):
+                break
+            elif key == ord(" ") and mode == InferenceMode.TRIGGER:
+                if rec.is_recording:
+                    if len(rec.frames) >= min_sign_frames:
+                        arr, alen = preprocess_sequence(rec.frames, scaler, max_len, normalize, True, seq_handling)
+                        cur_preds, _ = predict_sign(model, arr, alen, DEVICE, actions, top_k)
+                        history.append(cur_preds[0][0])
+                        print(f"Prediction ({len(rec.frames)} frames): {cur_preds[0][0]} ({cur_preds[0][1]*100:.1f}%)")
+                    else:
+                        print(f"Too few frames ({len(rec.frames)}), need {min_sign_frames}")
+                    rec.reset()
+                else:
+                    rec.is_recording = True
+                    rec.frames = []
+                    print("Recording started...")
+
+    cap.release()
+    if show_gui:
+        cv2.destroyAllWindows()
+
+    if mode == InferenceMode.VIDEO_FILE and rec.frames and vp is not None:
+        print(f"\n{'='*60}\nVIDEO FILE RESULTS\n{'='*60}")
+        print(f"Video: {vp.name}\nExpected class: {vp.parent.name}")
+        print(f"Frames extracted: {len(rec.frames)}")
+        arr, alen = preprocess_sequence(rec.frames, scaler, max_len, normalize, True, seq_handling)
+        preds, _ = predict_sign(model, arr, alen, DEVICE, actions, top_k)
+        exp = vp.parent.name
+        print(f"\nTop-{top_k} Predictions:")
+        for i, (c, p) in enumerate(preds):
+            mk = " <-- MATCH!" if c == exp else ""
+            print(f"  {i+1}. {c}: {p*100:.1f}%{mk}")
+        print(f"\nFinal prediction: {preds[0][0]}")
+        print(f"Ground truth: {exp}")
+        print(f"Correct: {'YES' if preds[0][0] == exp else 'NO'}")
+
+    if mode != InferenceMode.VIDEO_FILE and history:
+        print(f"\n{'='*60}\nSESSION SUMMARY\n{'='*60}")
+        print(f"Total predictions: {len(history)}")
+        print(f"Predictions: {' -> '.join(history[-10:])}")

--- a/tsl_recognition/evaluation/train.py
+++ b/tsl_recognition/evaluation/train.py
@@ -1,0 +1,645 @@
+"""
+Training loop, evaluation, and model persistence.
+
+Each training run creates a dedicated output directory under ``MODELS_DIR``::
+
+    models/run_20260210_143022_gru/
+        config.json          # full training config + arch + param count
+        best_model.pt        # best checkpoint (by val accuracy)
+        final_model.pt       # model at the end of training
+        checkpoints/         # periodic snapshots every 50 epochs
+        scores.json          # final test & val metrics + confusion matrix
+        training_log.csv     # per-epoch metrics
+        plots/
+            loss_curve.png
+            accuracy_curve.png
+
+Typical usage::
+
+    python -m tsl_recognition train                        # full training, default GRU
+    python -m tsl_recognition train --test                 # quick 10-class smoke test
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")  # headless backend — no display required
+import matplotlib.pyplot as plt
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim.lr_scheduler as lrs
+from sklearn.metrics import accuracy_score, multilabel_confusion_matrix
+
+from ..config import DEVICE, MODELS_DIR, SEED, TrainConfig, set_seed
+from ..dataset.loader import build_loaders
+from ..models import build_model
+
+# Checkpoint frequency (in epochs)
+CHECKPOINT_EVERY = 50
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def batch_accuracy(logits: torch.Tensor, targets: torch.Tensor) -> float:
+    """Calculate top-1 classification accuracy for a batch.
+
+    Parameters
+    ----------
+    logits : torch.Tensor
+        Raw model outputs of shape (batch_size, num_classes).
+    targets : torch.Tensor
+        Ground truth labels of shape (batch_size,).
+
+    Returns
+    -------
+    float
+        Top-1 accuracy as a fraction in [0, 1].
+    """
+    preds = torch.argmax(logits, dim=1)
+    return (preds == targets).float().mean().item()
+
+
+def batch_top_k_accuracy(
+    logits: torch.Tensor, targets: torch.Tensor, k: int = 5,
+) -> float:
+    """Calculate top-k classification accuracy for a batch.
+
+    A prediction is correct if the ground-truth label appears among the
+    *k* highest-scoring classes.
+
+    Parameters
+    ----------
+    logits : torch.Tensor
+        Raw model outputs of shape (batch_size, num_classes).
+    targets : torch.Tensor
+        Ground truth labels of shape (batch_size,).
+    k : int
+        Number of top predictions to consider (default: 5).
+
+    Returns
+    -------
+    float
+        Top-k accuracy as a fraction in [0, 1].
+    """
+    k = min(k, logits.size(1))
+    _, topk_preds = logits.topk(k, dim=1, largest=True, sorted=True)
+    correct = topk_preds.eq(targets.unsqueeze(1)).any(dim=1)
+    return correct.float().mean().item()
+
+
+def evaluate(model: nn.Module, loader, criterion) -> tuple[float, float, float]:
+    """Evaluate model on a dataset (validation or test set).
+
+    Parameters
+    ----------
+    model : nn.Module
+        The model to evaluate.
+    loader : DataLoader
+        DataLoader containing the evaluation dataset.
+        Each batch yields ``(xb, yb, lengths)`` where *lengths* holds
+        the actual (non-padded) sequence length for each sample.
+    criterion : nn.Module
+        Loss function (e.g., CrossEntropyLoss).
+
+    Returns
+    -------
+    tuple[float, float, float]
+        (average_loss, top1_accuracy, top5_accuracy) across all batches.
+    """
+    model.eval()
+    total_loss, total_acc, total_acc5, n_batches = 0.0, 0.0, 0.0, 0
+    with torch.no_grad():
+        for xb, yb, lengths in loader:
+            xb, yb = xb.to(DEVICE), yb.to(DEVICE)
+            lengths = lengths.to(DEVICE)
+            logits = model(xb, lengths=lengths)
+            total_loss += criterion(logits, yb).item()
+            total_acc += batch_accuracy(logits, yb)
+            total_acc5 += batch_top_k_accuracy(logits, yb, k=5)
+            n_batches += 1
+    return total_loss / n_batches, total_acc / n_batches, total_acc5 / n_batches
+
+
+def _build_scheduler(cfg: TrainConfig, optimizer: torch.optim.Optimizer, train_loader):
+    """Create the configured LR scheduler (or None).
+
+    Notes
+    -----
+    - OneCycleLR must be stepped *per batch*.
+    - CosineAnnealingWarmRestarts (+ optional warmup) is stepped *per epoch* here.
+    - ReduceLROnPlateau is stepped on validation epochs with the validation loss.
+    """
+    name = (cfg.lr_scheduler or "none").lower()
+
+    if name in {"none", "off", "false", "no"}:
+        return None
+
+    if name in {"plateau", "reduceonplateau", "reducelronplateau"}:
+        return lrs.ReduceLROnPlateau(
+            optimizer,
+            mode="min",
+            factor=0.5,
+            patience=15,
+        )
+
+    if name in {"onecycle", "onecyclelr"}:
+        steps_per_epoch = len(train_loader)
+        warmup_epochs = max(int(cfg.warmup_epochs), 0)
+        pct_start = warmup_epochs / max(int(cfg.epochs), 1)
+        pct_start = float(min(max(pct_start, 1e-3), 0.5))
+        if cfg.onecycle_max_lr is None:
+            cfg.onecycle_max_lr = float(min(5e-3, cfg.learning_rate * 5.0))
+        max_lr = float(cfg.onecycle_max_lr)
+        return lrs.OneCycleLR(
+            optimizer,
+            max_lr=max_lr,
+            epochs=cfg.epochs,
+            steps_per_epoch=steps_per_epoch,
+            pct_start=pct_start,
+            div_factor=cfg.onecycle_div_factor,
+            final_div_factor=cfg.onecycle_final_div_factor,
+            anneal_strategy="cos",
+        )
+
+    if name in {"cosine", "cosine_warm_restarts", "cosinewarmrestarts", "cosineannealingwarmrestarts"}:
+        cosine = lrs.CosineAnnealingWarmRestarts(
+            optimizer,
+            T_0=int(cfg.cosine_t0),
+            T_mult=int(cfg.cosine_t_mult),
+            eta_min=float(cfg.cosine_eta_min),
+        )
+
+        warmup_epochs = max(int(cfg.warmup_epochs), 0)
+        if warmup_epochs > 0:
+            warmup = lrs.LinearLR(
+                optimizer,
+                start_factor=float(cfg.warmup_start_factor),
+                total_iters=warmup_epochs,
+            )
+            return lrs.SequentialLR(
+                optimizer,
+                schedulers=[warmup, cosine],
+                milestones=[warmup_epochs],
+            )
+        return cosine
+
+    raise ValueError(
+        f"Unknown lr_scheduler={cfg.lr_scheduler!r}. "
+        "Expected one of: onecycle, cosine_warm_restarts, plateau, none."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run-directory helpers
+# ---------------------------------------------------------------------------
+def _create_run_dir(cfg: TrainConfig, timestamp: str) -> Path:
+    """Create and return the per-run output directory."""
+    run_dir = MODELS_DIR / f"run_{timestamp}_{cfg.model_arch}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "checkpoints").mkdir(exist_ok=True)
+    (run_dir / "plots").mkdir(exist_ok=True)
+    return run_dir
+
+
+def _save_config(
+    run_dir: Path,
+    cfg: TrainConfig,
+    feature_dim: int,
+    total_params: int,
+) -> None:
+    """Serialize training configuration + run metadata to config.json."""
+    meta = asdict(cfg)
+    meta.update({
+        "model_arch": cfg.model_arch,
+        "model_size": cfg.model_size,
+        "feature_dim": feature_dim,
+        "total_params": total_params,
+        "device": str(DEVICE),
+    })
+    (run_dir / "config.json").write_text(json.dumps(meta, indent=2))
+
+
+def _save_scores(
+    run_dir: Path,
+    test_acc: float,
+    test_acc5: float,
+    best_val_acc: float,
+    best_val_acc5: float,
+    cm: np.ndarray,
+    actions: np.ndarray,
+) -> None:
+    """Write final evaluation metrics to scores.json."""
+    per_class = {}
+    macro_precision, macro_recall, macro_f1 = 0.0, 0.0, 0.0
+    n_classes_with_support = 0
+
+    for i, label in enumerate(actions):
+        tn, fp, fn, tp = cm[i].ravel()
+        precision = float(tp / (tp + fp)) if (tp + fp) > 0 else 0.0
+        recall = float(tp / (tp + fn)) if (tp + fn) > 0 else 0.0
+        f1 = (
+            float(2 * precision * recall / (precision + recall))
+            if (precision + recall) > 0
+            else 0.0
+        )
+        support = int(tp + fn)
+        per_class[label] = {
+            "tp": int(tp), "fp": int(fp), "fn": int(fn), "tn": int(tn),
+            "precision": round(precision, 4),
+            "recall": round(recall, 4),
+            "f1": round(f1, 4),
+            "support": support,
+        }
+        if support > 0:
+            macro_precision += precision
+            macro_recall += recall
+            macro_f1 += f1
+            n_classes_with_support += 1
+
+    n = max(n_classes_with_support, 1)
+    scores = {
+        "test_accuracy": test_acc,
+        "test_top5_accuracy": test_acc5,
+        "best_val_accuracy": best_val_acc,
+        "best_val_top5_accuracy": best_val_acc5,
+        "num_classes": len(actions),
+        "macro_precision": round(macro_precision / n, 4),
+        "macro_recall": round(macro_recall / n, 4),
+        "macro_f1": round(macro_f1 / n, 4),
+        "per_class": per_class,
+    }
+    (run_dir / "scores.json").write_text(json.dumps(scores, indent=2))
+
+
+def _save_training_log(run_dir: Path, log_rows: list[dict]) -> None:
+    """Write per-epoch training metrics to training_log.csv."""
+    if not log_rows:
+        return
+    path = run_dir / "training_log.csv"
+    fieldnames = list(log_rows[0].keys())
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(log_rows)
+
+
+def _save_plots(run_dir: Path, log_rows: list[dict]) -> None:
+    """Generate loss and accuracy curve PNGs from the training log."""
+    if not log_rows:
+        return
+
+    epochs = [r["epoch"] for r in log_rows]
+    train_loss = [r["train_loss"] for r in log_rows]
+    train_acc = [r["train_acc"] for r in log_rows]
+    val_loss = [r["val_loss"] for r in log_rows if r["val_loss"] is not None]
+    val_acc = [r["val_acc"] for r in log_rows if r["val_acc"] is not None]
+    val_epochs = [r["epoch"] for r in log_rows if r["val_loss"] is not None]
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.plot(epochs, train_loss, label="Train loss")
+    if val_loss:
+        ax.plot(val_epochs, val_loss, label="Val loss")
+    ax.set_xlabel("Epoch")
+    ax.set_ylabel("Loss")
+    ax.set_title("Loss Curve")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(run_dir / "plots" / "loss_curve.png", dpi=150)
+    plt.close(fig)
+
+    train_acc5 = [r["train_acc5"] for r in log_rows if r.get("train_acc5") is not None]
+    train_acc5_epochs = [r["epoch"] for r in log_rows if r.get("train_acc5") is not None]
+    val_acc5 = [r["val_acc5"] for r in log_rows if r.get("val_acc5") is not None]
+    val_acc5_epochs = [r["epoch"] for r in log_rows if r.get("val_acc5") is not None]
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.plot(epochs, train_acc, label="Train top-1")
+    if val_acc:
+        ax.plot(val_epochs, val_acc, label="Val top-1")
+    if train_acc5:
+        ax.plot(train_acc5_epochs, train_acc5, label="Train top-5", linestyle="--")
+    if val_acc5:
+        ax.plot(val_acc5_epochs, val_acc5, label="Val top-5", linestyle="--")
+    ax.set_xlabel("Epoch")
+    ax.set_ylabel("Accuracy")
+    ax.set_title("Accuracy Curve (Top-1 & Top-5)")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(run_dir / "plots" / "accuracy_curve.png", dpi=150)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# xlarge auto-defaults
+# ---------------------------------------------------------------------------
+_XLARGE_DEFAULTS: dict[str, object] = {
+    "dropout": 0.2,
+    "epochs": 500,
+}
+
+
+def _apply_xlarge_defaults(cfg: TrainConfig) -> list[str]:
+    """Patch *cfg* in-place with xlarge-friendly values for fields that are
+    still at their ``TrainConfig`` defaults.  Returns a list of human-readable
+    messages describing what was changed."""
+    defaults = TrainConfig()
+    applied: list[str] = []
+
+    if cfg.dropout is None:
+        cfg.dropout = _XLARGE_DEFAULTS["dropout"]
+        applied.append(f"  dropout  : 0.4 → {cfg.dropout}")
+
+    if cfg.epochs == defaults.epochs:
+        cfg.epochs = _XLARGE_DEFAULTS["epochs"]
+        applied.append(f"  epochs   : {defaults.epochs} → {cfg.epochs}")
+
+    return applied
+
+
+# ---------------------------------------------------------------------------
+# Training entry point
+# ---------------------------------------------------------------------------
+def train(cfg: TrainConfig | None = None) -> dict:
+    """End-to-end training: data loading -> training -> evaluation -> save.
+
+    The training loop validates against the **validation** set (for LR
+    scheduling, early stopping, best-model checkpointing).  The **test** set
+    is used only once at the very end for the final reported accuracy.
+
+    All artifacts (checkpoints, scores, plots, config) are written to a
+    dedicated run directory under ``MODELS_DIR``.
+
+    Parameters
+    ----------
+    cfg : TrainConfig, optional
+        If *None*, uses the full training config.
+
+    Returns
+    -------
+    dict
+        ``model``, ``run_dir``, ``model_path``, ``test_accuracy``,
+        ``test_top5_accuracy``, ``best_val_acc``, ``best_val_top5_acc``,
+        ``actions``, ``feature_dim``, ``scaler``, ``class_weights``,
+        ``val_loader``, ``test_loader``, ``test_ds``,
+        ``train_files``, ``val_files``, ``test_files``
+    """
+    if cfg is None:
+        cfg = TrainConfig.full()
+
+    set_seed(SEED)
+
+    model_size = cfg.model_size
+    if model_size == "xlarge":
+        tweaks = _apply_xlarge_defaults(cfg)
+        if tweaks:
+            print("\n[xlarge] Auto-applied training defaults:")
+            for msg in tweaks:
+                print(msg)
+
+    if cfg.dropout is None:
+        cfg.dropout = 0.4
+
+    run_stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = _create_run_dir(cfg, run_stamp)
+    print(f"\nRun directory: {run_dir}")
+
+    data = build_loaders(cfg)
+    train_loader = data["train_loader"]
+    val_loader = data["val_loader"]
+    test_loader = data["test_loader"]
+    test_ds = data["test_ds"]
+    class_weights = data["class_weights"]
+    feature_dim = data["feature_dim"]
+    scaler = data["scaler"]
+    actions = cfg.actions
+
+    print(f"\nArchitecture: {cfg.model_arch} ({model_size}) for {cfg.num_classes} classes")
+    print(f"Dropout: {cfg.dropout}")
+
+    model = build_model(
+        arch=cfg.model_arch,
+        input_size=feature_dim,
+        num_classes=cfg.num_classes,
+        model_size=model_size,
+        dropout=cfg.dropout,
+    ).to(DEVICE)
+
+    total_params = sum(p.numel() for p in model.parameters())
+    print(f"Model parameters: {total_params:,}")
+
+    _save_config(run_dir, cfg, feature_dim, total_params)
+
+    ls = cfg.label_smoothing if cfg.label_smoothing > 0 else 0.0
+    if cfg.use_class_weights:
+        criterion = nn.CrossEntropyLoss(weight=class_weights, label_smoothing=ls)
+        print("Using weighted CrossEntropyLoss for class imbalance")
+    else:
+        criterion = nn.CrossEntropyLoss(label_smoothing=ls)
+    if ls > 0:
+        print(f"Label smoothing: {ls}")
+
+    optimizer = torch.optim.Adam(
+        model.parameters(),
+        lr=cfg.learning_rate,
+        weight_decay=1e-4,
+    )
+
+    scheduler = _build_scheduler(cfg, optimizer, train_loader)
+    if scheduler is None:
+        print("LR scheduler: none (fixed learning rate)")
+    else:
+        print(f"LR scheduler: {cfg.lr_scheduler}")
+    if cfg.grad_clip_norm > 0:
+        print(f"Gradient clipping: max_norm={cfg.grad_clip_norm}")
+    else:
+        print("Gradient clipping: OFF")
+    if cfg.early_stopping_patience > 0:
+        print(f"Early stopping: patience={cfg.early_stopping_patience} epochs (min_epochs={cfg.min_epochs})")
+    else:
+        print("Early stopping: OFF")
+    print(f"Validation every {cfg.val_every} epoch(s)")
+
+    best_val_acc = 0.0
+    best_val_acc5 = 0.0
+    best_val_epoch = 0
+    log_rows: list[dict] = []
+    best_model_path = run_dir / "best_model.pt"
+
+    print(f"\nTraining for {cfg.epochs} epochs with lr={cfg.learning_rate}")
+    print("-" * 60)
+
+    for epoch in range(1, cfg.epochs + 1):
+        model.train()
+        running_loss = 0.0
+        running_acc = 0.0
+        running_acc5 = 0.0
+
+        for xb, yb, lengths in train_loader:
+            xb, yb = xb.to(DEVICE), yb.to(DEVICE)
+            lengths = lengths.to(DEVICE)
+            optimizer.zero_grad()
+            logits = model(xb, lengths=lengths)
+            loss = criterion(logits, yb)
+            loss.backward()
+            if cfg.grad_clip_norm > 0:
+                nn.utils.clip_grad_norm_(model.parameters(), cfg.grad_clip_norm)
+            optimizer.step()
+            if isinstance(scheduler, lrs.OneCycleLR):
+                scheduler.step()
+            running_loss += loss.item()
+            detached = logits.detach()
+            running_acc += batch_accuracy(detached, yb)
+            running_acc5 += batch_top_k_accuracy(detached, yb, k=5)
+
+        train_loss = running_loss / len(train_loader)
+        train_acc = running_acc / len(train_loader)
+        train_acc5 = running_acc5 / len(train_loader)
+        current_lr = optimizer.param_groups[0]["lr"]
+
+        val_loss, val_acc, val_acc5 = None, None, None
+        if epoch == 1 or epoch % cfg.val_every == 0 or epoch == cfg.epochs:
+            val_loss, val_acc, val_acc5 = evaluate(model, val_loader, criterion)
+            if isinstance(scheduler, lrs.ReduceLROnPlateau):
+                scheduler.step(val_loss)
+
+            if val_acc > best_val_acc:
+                best_val_acc = val_acc
+                best_val_acc5 = val_acc5
+                best_val_epoch = epoch
+                best_marker = " * (saved)"
+                torch.save(model.state_dict(), best_model_path)
+            else:
+                best_marker = ""
+
+            print(
+                f"Epoch {epoch:3d}/{cfg.epochs} | "
+                f"train_loss {train_loss:.4f} | "
+                f"train_acc {train_acc:.4f} (top5 {train_acc5:.4f}) | "
+                f"val_loss {val_loss:.4f} | "
+                f"val_acc {val_acc:.4f} (top5 {val_acc5:.4f}) | "
+                f"lr {current_lr:.1e}{best_marker}"
+            )
+
+        if scheduler is not None and not isinstance(scheduler, (lrs.OneCycleLR, lrs.ReduceLROnPlateau)):
+            scheduler.step()
+
+        log_rows.append({
+            "epoch": epoch,
+            "train_loss": round(train_loss, 6),
+            "train_acc": round(train_acc, 6),
+            "train_acc5": round(train_acc5, 6),
+            "val_loss": round(val_loss, 6) if val_loss is not None else None,
+            "val_acc": round(val_acc, 6) if val_acc is not None else None,
+            "val_acc5": round(val_acc5, 6) if val_acc5 is not None else None,
+            "lr": current_lr,
+        })
+
+        if epoch % CHECKPOINT_EVERY == 0:
+            ckpt_path = run_dir / "checkpoints" / f"epoch_{epoch:03d}.pt"
+            torch.save(model.state_dict(), ckpt_path)
+
+        if (
+            cfg.early_stopping_patience > 0
+            and best_val_epoch > 0
+            and epoch >= cfg.min_epochs
+            and (epoch - best_val_epoch) >= cfg.early_stopping_patience
+        ):
+            print(
+                f"\nEarly stopping at epoch {epoch}: "
+                f"no val accuracy improvement for {cfg.early_stopping_patience} epochs "
+                f"(best val_acc={best_val_acc:.4f} at epoch {best_val_epoch})"
+            )
+            break
+
+    print("-" * 60)
+    print(f"Best validation accuracy: {best_val_acc:.4f} top-1, {best_val_acc5:.4f} top-5 (epoch {best_val_epoch})")
+
+    final_model_path = run_dir / "final_model.pt"
+    torch.save(model.state_dict(), final_model_path)
+    print(f"Final model saved to: {final_model_path}")
+
+    if best_model_path.exists():
+        model.load_state_dict(
+            torch.load(best_model_path, map_location=DEVICE, weights_only=True)
+        )
+        print("Restored best model weights")
+
+    model.eval()
+    with torch.no_grad():
+        sample_x, sample_y, sample_len = test_ds[0]
+        sample_logits = model(
+            sample_x.unsqueeze(0).to(DEVICE),
+            lengths=sample_len.unsqueeze(0).to(DEVICE),
+        )
+        pred = sample_logits.argmax(dim=1).cpu().item()
+    print(f"Prediction: {actions[pred]}")
+    print(f"Ground truth: {actions[sample_y.item()]}")
+
+    print(f"\n{'='*60}")
+    print("FINAL EVALUATION ON HELD-OUT TEST SET")
+    print(f"{'='*60}")
+    loaded_model = build_model(
+        arch=cfg.model_arch,
+        input_size=feature_dim,
+        num_classes=cfg.num_classes,
+        model_size=model_size,
+        dropout=cfg.dropout,
+    ).to(DEVICE)
+    loaded_model.load_state_dict(
+        torch.load(best_model_path, map_location=DEVICE, weights_only=True)
+    )
+    loaded_model.eval()
+
+    all_logits_list, all_true = [], []
+    with torch.no_grad():
+        for xb, yb, lengths in test_loader:
+            logits = loaded_model(xb.to(DEVICE), lengths=lengths.to(DEVICE))
+            all_logits_list.append(logits.cpu())
+            all_true.extend(yb.numpy().tolist())
+
+    all_logits = torch.cat(all_logits_list, dim=0)
+    all_targets = torch.tensor(all_true, dtype=torch.long)
+    all_preds = torch.argmax(all_logits, dim=1).numpy().tolist()
+
+    all_labels = list(range(cfg.num_classes))
+    test_acc = accuracy_score(all_true, all_preds)
+    test_acc5 = batch_top_k_accuracy(all_logits, all_targets, k=5)
+    cm = multilabel_confusion_matrix(all_true, all_preds, labels=all_labels)
+    print(f"Test Accuracy (top-1): {test_acc:.4f}")
+    print(f"Test Accuracy (top-5): {test_acc5:.4f}")
+
+    _save_scores(run_dir, test_acc, test_acc5, best_val_acc, best_val_acc5, cm, actions)
+    _save_training_log(run_dir, log_rows)
+    _save_plots(run_dir, log_rows)
+    print(f"\nAll artifacts saved to: {run_dir}")
+
+    return {
+        "model": loaded_model,
+        "run_dir": run_dir,
+        "model_path": best_model_path,
+        "test_accuracy": test_acc,
+        "test_top5_accuracy": test_acc5,
+        "best_val_acc": best_val_acc,
+        "best_val_top5_acc": best_val_acc5,
+        "actions": actions,
+        "feature_dim": feature_dim,
+        "scaler": scaler,
+        "class_weights": class_weights,
+        "val_loader": val_loader,
+        "test_loader": test_loader,
+        "test_ds": test_ds,
+        "train_files": data["train_files"],
+        "val_files": data["val_files"],
+        "test_files": data["test_files"],
+    }

--- a/tsl_recognition/evaluation/validate.py
+++ b/tsl_recognition/evaluation/validate.py
@@ -1,0 +1,193 @@
+"""
+Validate that the inference preprocessing pipeline matches training.
+
+Loads raw .npy keypoint files from the persisted **test** split and compares
+predictions using:
+  1. Training pipeline (LazySignDataset-style)
+  2. Inference pipeline (preprocess_sequence)
+
+If both produce the same predictions the inference pipeline is correct.
+
+Usage::
+
+    python -m tsl_recognition validate
+    python -m tsl_recognition validate --samples 200
+    python -m tsl_recognition validate --run-dir trained-models/run_20260216_011133_gru
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+import numpy as np
+import torch
+from tqdm.auto import tqdm
+
+from ..config import DEVICE, MODELS_DIR, TrainConfig
+from ..dataset.loader import LazySignDataset
+from .inference import _find_latest_run, _load_run, preprocess_sequence
+
+
+def _load_test_files(
+    split_dir: Path,
+    actions: np.ndarray,
+) -> list[tuple[str, int, int]]:
+    """Load test-split file list from the persisted manifest.
+
+    Parameters
+    ----------
+    split_dir : Path
+        Directory containing the split JSON manifests.
+    actions : np.ndarray
+        Ordered class names (the label map is derived from the index).
+
+    Returns
+    -------
+    list of (path, label_int, num_frames)
+    """
+    manifest = split_dir / "test.json"
+    if not manifest.exists():
+        raise FileNotFoundError(
+            f"No test manifest at {manifest}. Run `python -m tsl_recognition split` first."
+        )
+    with open(manifest) as f:
+        entries = json.load(f)
+
+    label_map = {name: idx for idx, name in enumerate(actions)}
+    allowed = set(label_map)
+    files: list[tuple[str, int, int]] = []
+    dropped = 0
+    for e in entries:
+        cls = e.get("class_name")
+        if cls not in allowed:
+            dropped += 1
+            continue
+        files.append((e["path"], label_map[cls], int(e["num_frames"])))
+    if dropped:
+        print(f"Filtered test split: dropped {dropped} samples outside run classes")
+    return files
+
+
+def run_validation(
+    run_dir: Path | str | None = None,
+    n_samples: int = 100,
+    dataset: str = "bosphorus",
+) -> dict:
+    """Compare training vs inference preprocessing on *n_samples* test files.
+
+    Uses the persisted test split to ensure the same held-out samples are
+    evaluated every time.
+
+    Parameters
+    ----------
+    run_dir : Path | str | None
+        Path to a ``run_*`` directory produced by ``train.py``.  If *None*,
+        the most recent run directory under ``MODELS_DIR`` is used.
+    n_samples : int
+        Number of test-split samples to compare.
+    dataset : str
+        Dataset name used to locate the correct split directory.
+
+    Returns
+    -------
+    dict
+        Accuracy and match statistics.
+    """
+    rd = Path(run_dir) if run_dir is not None else _find_latest_run(MODELS_DIR)
+    run_data = _load_run(rd)
+    model = run_data["model"]
+    scaler = run_data["scaler"]
+    actions = run_data["actions"]
+    max_len = run_data["max_len"]
+    seq_handling = run_data["sequence_handling"]
+    normalize = run_data["normalize"]
+    feature_dim = run_data["feature_dim"]
+
+    split_dir = TrainConfig(dataset=dataset).dataset_info.split_dir
+    test_files = _load_test_files(split_dir, actions)
+    if not test_files:
+        raise RuntimeError("No test files found in split manifest matching run classes.")
+
+    train_baseline_ds = LazySignDataset(
+        file_info_list=test_files,
+        max_seq_len=max_len,
+        feature_dim=feature_dim,
+        scaler=scaler,
+        augment=False,
+        sequence_handling=seq_handling,
+    )
+
+    random.seed(42)
+    indices = list(range(len(test_files)))
+    sampled = random.sample(indices, min(n_samples, len(indices)))
+    print(f"\nValidating inference pipeline on {len(sampled)} test-split samples...")
+    print(f"Run directory: {rd.name}\n")
+
+    results = dict(training_correct=0, inference_correct=0, both_match=0, both_correct=0)
+    mismatches: list[dict] = []
+
+    for idx in tqdm(sampled, desc="Validating"):
+        path, label, _ = test_files[idx]
+        true_cls = actions[label]
+
+        tkp, _lbl, t_len = train_baseline_ds[idx]
+        with torch.no_grad():
+            t_logits = model(
+                tkp.unsqueeze(0).to(DEVICE),
+                lengths=t_len.unsqueeze(0).to(DEVICE),
+            )
+            train_cls = actions[torch.argmax(t_logits, dim=1).item()]
+
+        raw = np.load(path).astype(np.float32)
+        frames = [raw[i] for i in range(len(raw))]
+        ikp, actual_len = preprocess_sequence(
+            frames, scaler, max_len,
+            normalize=normalize,
+            apply_interpolation=True,
+            sequence_handling=seq_handling,
+        )
+        with torch.no_grad():
+            i_logits = model(
+                torch.tensor(ikp, dtype=torch.float32).unsqueeze(0).to(DEVICE),
+                lengths=torch.tensor([actual_len], dtype=torch.long).to(DEVICE),
+            )
+            inf_cls = actions[torch.argmax(i_logits, dim=1).item()]
+
+        if train_cls == true_cls:
+            results["training_correct"] += 1
+        if inf_cls == true_cls:
+            results["inference_correct"] += 1
+        if train_cls == inf_cls:
+            results["both_match"] += 1
+        if train_cls == true_cls and inf_cls == true_cls:
+            results["both_correct"] += 1
+        if train_cls != inf_cls:
+            mismatches.append(dict(file=path, true=true_cls, train=train_cls, inf=inf_cls))
+
+    n = len(sampled)
+    print(f"\n{'='*60}\nVALIDATION RESULTS\n{'='*60}")
+    print(f"Samples tested: {n}\n")
+    print(f"Training pipeline accuracy:  {results['training_correct']/n*100:.1f}% ({results['training_correct']}/{n})")
+    print(f"Inference pipeline accuracy: {results['inference_correct']/n*100:.1f}% ({results['inference_correct']}/{n})\n")
+    print(f"Predictions match:           {results['both_match']/n*100:.1f}% ({results['both_match']}/{n})")
+    print(f"Both correct:                {results['both_correct']/n*100:.1f}% ({results['both_correct']}/{n})")
+
+    if mismatches:
+        print(f"\nMismatches ({len(mismatches)} samples):")
+        for m in mismatches[:10]:
+            print(f"  True: {m['true']}, Training: {m['train']}, Inference: {m['inf']}")
+        if len(mismatches) > 10:
+            print(f"  ... and {len(mismatches) - 10} more")
+    else:
+        print("\nAll predictions match! Inference pipeline is correctly aligned with training.")
+
+    print(f"\n{'-'*60}")
+    if results["both_match"] == n:
+        print("PASS: Inference preprocessing produces identical results to training.")
+    elif results["both_match"] / n > 0.95:
+        print("MOSTLY PASS: Minor differences likely due to interpolation.")
+    else:
+        print("WARNING: Significant mismatch between training and inference pipelines.")
+    return results

--- a/tsl_recognition/evaluation/visualization.py
+++ b/tsl_recognition/evaluation/visualization.py
@@ -1,0 +1,231 @@
+"""Drawing helpers for MediaPipe landmarks and inference HUD.
+
+This module provides functions to visualize:
+1. Detected landmarks (face, hands, pose) on video frames
+2. Inference status and predictions (HUD overlay)
+"""
+from __future__ import annotations
+
+import time
+
+import cv2
+import mediapipe as mp
+import numpy as np
+
+try:
+    _hands = mp.tasks.vision.HandLandmarksConnections
+    _face = mp.tasks.vision.FaceLandmarksConnections
+    _draw = mp.tasks.vision.drawing_utils
+    _sty = mp.tasks.vision.drawing_styles
+    HAS_DRAW = True
+except Exception:
+    HAS_DRAW = False
+
+HAS_POSE = False
+if HAS_DRAW:
+    try:
+        _pose = mp.tasks.vision.PoseLandmarksConnections
+        HAS_POSE = True
+    except Exception:
+        pass
+
+
+def _pts(frame, lms, color, r=2):
+    """Draw simple circles for landmarks (fallback when MediaPipe drawing not available).
+
+    Parameters
+    ----------
+    frame : np.ndarray
+        BGR frame to draw on.
+    lms : list
+        List of landmark objects with x, y attributes (normalized 0-1).
+    color : tuple
+        BGR color tuple.
+    r : int, optional
+        Circle radius in pixels (default: 2).
+    """
+    h, w = frame.shape[:2]
+    for lm in lms:
+        cv2.circle(frame, (int(lm.x * w), int(lm.y * h)), r, color, -1)
+
+
+def draw_hand_landmarks(f, hr):
+    """Draw hand landmarks with connections and handedness labels.
+
+    Parameters
+    ----------
+    f : np.ndarray
+        Input BGR frame.
+    hr : HandLandmarkerResult
+        Hand detection result from MediaPipe.
+
+    Returns
+    -------
+    np.ndarray
+        Frame with hand landmarks drawn.
+    """
+    if not HAS_DRAW or not hr.hand_landmarks:
+        return f
+    rgb = cv2.cvtColor(f, cv2.COLOR_BGR2RGB).copy()
+    for i, hlm in enumerate(hr.hand_landmarks):
+        _draw.draw_landmarks(
+            rgb, hlm, _hands.HAND_CONNECTIONS,
+            _sty.get_default_hand_landmarks_style(),
+            _sty.get_default_hand_connections_style(),
+        )
+        if hr.handedness and i < len(hr.handedness):
+            lb = hr.handedness[i][0].category_name
+            h, w, _ = rgb.shape
+            tx = int(min(l.x for l in hlm) * w)
+            ty = int(min(l.y for l in hlm) * h) - 10
+            cv2.putText(rgb, lb, (tx, max(0, ty)), cv2.FONT_HERSHEY_DUPLEX, 0.6, (88, 205, 54), 1, cv2.LINE_AA)
+    return cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
+
+
+def draw_face_landmarks(f, fr):
+    """Draw face mesh landmarks with tessellation and contours.
+
+    Parameters
+    ----------
+    f : np.ndarray
+        Input BGR frame.
+    fr : FaceLandmarkerResult
+        Face detection result from MediaPipe.
+
+    Returns
+    -------
+    np.ndarray
+        Frame with face landmarks drawn.
+    """
+    if not HAS_DRAW or not fr.face_landmarks:
+        return f
+    rgb = cv2.cvtColor(f, cv2.COLOR_BGR2RGB).copy()
+    for flm in fr.face_landmarks:
+        for conn, sfn in [
+            (_face.FACE_LANDMARKS_TESSELATION, _sty.get_default_face_mesh_tesselation_style),
+            (_face.FACE_LANDMARKS_CONTOURS, _sty.get_default_face_mesh_contours_style),
+            (_face.FACE_LANDMARKS_LEFT_IRIS, _sty.get_default_face_mesh_iris_connections_style),
+            (_face.FACE_LANDMARKS_RIGHT_IRIS, _sty.get_default_face_mesh_iris_connections_style),
+        ]:
+            _draw.draw_landmarks(
+                image=rgb, landmark_list=flm, connections=conn,
+                landmark_drawing_spec=None, connection_drawing_spec=sfn(),
+            )
+    return cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
+
+
+def draw_pose_landmarks(f, pr):
+    """Draw pose (body) landmarks with skeletal connections.
+
+    Parameters
+    ----------
+    f : np.ndarray
+        Input BGR frame.
+    pr : PoseLandmarkerResult
+        Pose detection result from MediaPipe.
+
+    Returns
+    -------
+    np.ndarray
+        Frame with pose landmarks drawn.
+    """
+    if not HAS_POSE or not pr.pose_landmarks:
+        return f
+    rgb = cv2.cvtColor(f, cv2.COLOR_BGR2RGB).copy()
+    cs = _draw.DrawingSpec(color=(0, 255, 0), thickness=2)
+    ls = _sty.get_default_pose_landmarks_style()
+    for plm in pr.pose_landmarks:
+        _draw.draw_landmarks(rgb, plm, _pose.POSE_LANDMARKS, ls, cs)
+    return cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
+
+
+def draw_results(frame, face_r, hand_r, pose_r):
+    """Draw all detected landmarks on a BGR frame.
+
+    Parameters
+    ----------
+    frame : np.ndarray
+        Input BGR frame.
+    face_r : FaceLandmarkerResult
+        Face detection result.
+    hand_r : HandLandmarkerResult
+        Hand detection result.
+    pose_r : PoseLandmarkerResult
+        Pose detection result.
+
+    Returns
+    -------
+    np.ndarray
+        Frame with all landmarks drawn.
+    """
+    frame = draw_hand_landmarks(frame, hand_r)
+    frame = draw_face_landmarks(frame, face_r)
+    frame = draw_pose_landmarks(frame, pose_r)
+    if not HAS_DRAW and face_r.face_landmarks:
+        _pts(frame, face_r.face_landmarks[0], (0, 180, 255), 1)
+    if not HAS_POSE and pose_r.pose_landmarks:
+        _pts(frame, pose_r.pose_landmarks[0], (0, 255, 0), 3)
+    return frame
+
+
+def draw_status_bar(frame, recorder, mode, predictions=None, debug_info=None):
+    """Draw the HUD status bar at the top of the frame.
+
+    Parameters
+    ----------
+    frame : np.ndarray
+        BGR frame to draw on (modified in-place).
+    recorder : SignRecorder
+        Current recording state.
+    mode : InferenceMode
+        Current inference mode.
+    predictions : list | None, optional
+        List of (class_name, probability) tuples.
+    debug_info : dict | None, optional
+        Debug information (e.g., motion values).
+
+    Returns
+    -------
+    np.ndarray
+        Frame with HUD overlay drawn.
+    """
+    from .inference import InferenceMode
+
+    h, w = frame.shape[:2]
+    cv2.rectangle(frame, (0, 0), (w, 140), (20, 20, 20), -1)
+    mc = {
+        InferenceMode.TRIGGER: (0, 255, 255),
+        InferenceMode.MOTION: (0, 255, 0),
+        InferenceMode.CONTINUOUS: (255, 128, 0),
+        InferenceMode.VIDEO_FILE: (255, 0, 255),
+    }
+    cv2.putText(frame, f"Mode: {mode.name}", (10, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.7, mc.get(mode, (255, 255, 255)), 2, cv2.LINE_AA)
+
+    if recorder.is_recording:
+        cv2.putText(frame, f"RECORDING: {len(recorder.frames)} frames", (10, 50), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 255), 1, cv2.LINE_AA)
+        if int(time.time() * 4) % 2:
+            cv2.circle(frame, (w - 30, 20), 10, (0, 0, 255), -1)
+    else:
+        cv2.putText(frame, "Ready (waiting for sign)", (10, 50), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (100, 100, 100), 1, cv2.LINE_AA)
+
+    if mode == InferenceMode.MOTION and debug_info:
+        sm = debug_info.get("smoothed_motion", 0)
+        bw = int(min(debug_info.get("motion", 0) * 2000, 200))
+        cv2.rectangle(frame, (10, 60), (10 + bw, 75), (0, 200, 200), -1)
+        cv2.rectangle(frame, (10, 60), (210, 75), (100, 100, 100), 1)
+        cv2.putText(frame, f"Motion: {sm:.4f}", (220, 73), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (150, 150, 150), 1, cv2.LINE_AA)
+
+    if predictions:
+        y0 = 85
+        cv2.putText(frame, "Predictions:", (10, y0), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 1, cv2.LINE_AA)
+        for i, (cls, prob) in enumerate(predictions[:3]):
+            y = y0 + 18 + i * 16
+            cv2.rectangle(frame, (100, y - 10), (100 + int(prob * 150), y), (0, 180, 0), -1)
+            cv2.putText(frame, f"{cls}: {prob * 100:.1f}%", (260, y), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 255, 255), 1, cv2.LINE_AA)
+
+    if mode == InferenceMode.TRIGGER:
+        cv2.putText(frame, "SPACE start/stop, 'q' quit", (10, h - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (150, 150, 150), 1, cv2.LINE_AA)
+    elif mode == InferenceMode.MOTION:
+        cv2.putText(frame, "Move hands to auto-detect, 'q' quit", (10, h - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (150, 150, 150), 1, cv2.LINE_AA)
+
+    return frame


### PR DESCRIPTION
## What does this PR do?

Moves the training, inference, evaluate, validate, and visualization modules into `tsl_recognition/evaluation/`. Adds `cli.py` and `__main__.py` so `python -m tsl_recognition` works. Three fixes in `inference.py`: scaler now loads from `dataset_info.processed_dir` instead of the removed `DATA_PATH`; webcam init uses `getattr(cv2, "CAP_V4L2", cv2.CAP_ANY)` for portability; `_has_display()` returns `True` on Windows. Video mode drops the hardcoded fallback path -- `--video` is now required.

Closes #4

## Which pipeline does it touch?
- [x] TSL Recognition
- [ ] Gloss-to-Text
- [ ] Shared scripts/configs

## Experiment details (if applicable)
- Dataset: N/A
- Model variant: N/A
- Key metric change: N/A

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Training configs are reproducible (seeds, hyperparams documented) -- `set_seed(SEED)` at start of `train()`, full config serialized to `config.json`
- [x] No large binary files committed directly (use LFS or external storage)