### PR TITLE
test(recognition, translation): add smoke tests for both pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ sozia-research/
 │   ├── prompts/                # Prompt strategies (P1–P3 × EN/TR)
 │   ├── fine_tuning/            # LoRA fine-tuning
 │   └── evaluation/             # Baseline, RAG, and Gemini judge
+├── tests/                      # Smoke tests (no data required)
+│   ├── test_recognition_smoke.py
+│   └── test_translation_smoke.py
 ├── scripts/                    # Data preparation utilities
 │   └── prepare_data.py
 └── notebooks/                  # Exploratory notebooks
@@ -85,6 +88,19 @@ python -m gloss_to_text.fine_tuning.unified_bench \
 
 # Score predictions with Gemini judge
 python -m gloss_to_text.evaluation.gemini_judge
+```
+
+## Development
+
+```bash
+# Install dev dependencies (pytest, ruff, mypy, etc.)
+pip install -e ".[dev]"
+
+# Run smoke tests (no data or GPU required)
+pytest
+
+# Run with coverage
+pytest --cov=tsl_recognition --cov=gloss_to_text --cov-report=term-missing
 ```
 
 ## Environment variables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ translation = [
 dev = [
     "jupyter>=1.0",
     "ipykernel",
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.4",
+    "mypy>=1.10",
 ]
 
 [project.scripts]
@@ -43,3 +47,9 @@ tsl-recognition = "tsl_recognition.cli:main"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["tsl_recognition*", "gloss_to_text*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+addopts = "-v --tb=short"

--- a/tests/test_recognition_smoke.py
+++ b/tests/test_recognition_smoke.py
@@ -1,0 +1,207 @@
+"""Smoke tests for the tsl_recognition pipeline.
+
+These tests verify that modules import cleanly, core objects can be
+constructed with no data on disk, and the GRU model produces output of
+the expected shape.  No GPU, no real dataset files required.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+
+# ---------------------------------------------------------------------------
+# 1. Import smoke
+# ---------------------------------------------------------------------------
+
+def test_tsl_recognition_imports() -> None:
+    """tsl_recognition package-level import must succeed."""
+    import tsl_recognition  # noqa: F401
+
+
+def test_tsl_recognition_submodules_import() -> None:
+    """Core sub-modules must be importable without side-effects."""
+    from tsl_recognition import config  # noqa: F401
+    from tsl_recognition.models import MODEL_REGISTRY, build_model  # noqa: F401
+    from tsl_recognition.dataset import registry  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# 2. TrainConfig defaults
+# ---------------------------------------------------------------------------
+
+def test_train_config_default_construction() -> None:
+    """TrainConfig() with no arguments must use documented defaults."""
+    from tsl_recognition.config import TrainConfig
+
+    cfg = TrainConfig()
+
+    assert cfg.dataset == "bosphorus"
+    assert cfg.classes_to_process == []
+    assert cfg.max_sequence_length == 150
+    assert cfg.min_sequence_length == 10
+    assert cfg.batch_size == 64
+    assert cfg.epochs == 300
+    assert cfg.learning_rate == pytest.approx(5e-4)
+    assert cfg.model_arch == "gru"
+    assert cfg.lr_scheduler == "onecycle"
+
+
+def test_train_config_num_classes_reflects_classes_list() -> None:
+    """num_classes property must equal len(classes_to_process)."""
+    from tsl_recognition.config import TrainConfig
+
+    cfg = TrainConfig(classes_to_process=["A", "B", "C"])
+    assert cfg.num_classes == 3
+
+
+def test_train_config_model_size_small_threshold() -> None:
+    """model_size is 'small' for <=50 classes, 'large' for >50."""
+    from tsl_recognition.config import TrainConfig
+
+    small_cfg = TrainConfig(classes_to_process=list(map(str, range(50))))
+    assert small_cfg.model_size == "small"
+
+    large_cfg = TrainConfig(classes_to_process=list(map(str, range(51))))
+    assert large_cfg.model_size == "large"
+
+
+def test_train_config_model_size_override() -> None:
+    """model_size_override must take precedence over the auto-detection rule."""
+    from tsl_recognition.config import TrainConfig
+
+    cfg = TrainConfig(
+        classes_to_process=list(map(str, range(10))),
+        model_size_override="xlarge",
+    )
+    assert cfg.model_size == "xlarge"
+
+
+def test_train_config_feature_dim_constant() -> None:
+    """FEATURE_DIM must equal 507 (pose + face + hands)."""
+    from tsl_recognition.config import FEATURE_DIM
+
+    assert FEATURE_DIM == 507
+
+
+# ---------------------------------------------------------------------------
+# 3. Model registry + GRU forward pass
+# ---------------------------------------------------------------------------
+
+def test_model_registry_contains_gru() -> None:
+    """MODEL_REGISTRY must expose a 'gru' key."""
+    from tsl_recognition.models import MODEL_REGISTRY
+
+    assert "gru" in MODEL_REGISTRY
+
+
+def test_build_model_returns_nn_module() -> None:
+    """build_model('gru', ...) must return a torch.nn.Module."""
+    import torch.nn as nn
+    from tsl_recognition.models import build_model
+
+    model = build_model(arch="gru", input_size=507, num_classes=10, model_size="small")
+    assert isinstance(model, nn.Module)
+
+
+def test_build_model_unknown_arch_raises() -> None:
+    """build_model with an unknown arch must raise ValueError."""
+    from tsl_recognition.models import build_model
+
+    with pytest.raises(ValueError, match="Unknown architecture"):
+        build_model(arch="nonexistent", input_size=507, num_classes=10)
+
+
+def test_gru_forward_pass_output_shape() -> None:
+    """GRU forward pass on a tiny dummy batch must produce the right output shape."""
+    from tsl_recognition.models import build_model
+
+    model = build_model(arch="gru", input_size=507, num_classes=10, model_size="small")
+    model.eval()
+
+    # (batch=2, seq_len=5, features=507)
+    dummy = torch.zeros(2, 5, 507)
+
+    with torch.no_grad():
+        logits = model(dummy)
+
+    assert logits.shape == (2, 10), f"Expected (2, 10), got {logits.shape}"
+
+
+def test_gru_forward_pass_is_finite() -> None:
+    """GRU output on zero input must contain no NaN or Inf values."""
+    from tsl_recognition.models import build_model
+
+    model = build_model(arch="gru", input_size=507, num_classes=5, model_size="small")
+    model.eval()
+
+    dummy = torch.zeros(2, 5, 507)
+
+    with torch.no_grad():
+        logits = model(dummy)
+
+    assert torch.isfinite(logits).all(), "logits contain NaN or Inf"
+
+
+# ---------------------------------------------------------------------------
+# 4. Dataset registry
+# ---------------------------------------------------------------------------
+
+def test_dataset_registry_contains_known_datasets() -> None:
+    """DATASET_REGISTRY must include 'bosphorus' and 'autsl'."""
+    from tsl_recognition.dataset.registry import DATASET_REGISTRY
+
+    assert "bosphorus" in DATASET_REGISTRY
+    assert "autsl" in DATASET_REGISTRY
+
+
+def test_get_dataset_info_bosphorus_returns_instance(tmp_path: Path) -> None:
+    """get_dataset_info('bosphorus', ...) must return a DatasetInfo without data on disk."""
+    from tsl_recognition.dataset.base import DatasetInfo
+    from tsl_recognition.dataset.registry import get_dataset_info
+
+    info = get_dataset_info("bosphorus", tmp_path)
+
+    assert isinstance(info, DatasetInfo)
+    assert info.name == "bosphorus"
+
+
+def test_get_dataset_info_autsl_returns_instance(tmp_path: Path) -> None:
+    """get_dataset_info('autsl', ...) must return a DatasetInfo without data on disk."""
+    from tsl_recognition.dataset.base import DatasetInfo
+    from tsl_recognition.dataset.registry import get_dataset_info
+
+    info = get_dataset_info("autsl", tmp_path)
+
+    assert isinstance(info, DatasetInfo)
+    assert info.name == "autsl"
+
+
+def test_get_dataset_info_unknown_raises(tmp_path: Path) -> None:
+    """get_dataset_info with an unknown name must raise ValueError."""
+    from tsl_recognition.dataset.registry import get_dataset_info
+
+    with pytest.raises(ValueError, match="Unknown dataset"):
+        get_dataset_info("nonexistent", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 5. CLI --help exits 0
+# ---------------------------------------------------------------------------
+
+def test_cli_help_exits_zero() -> None:
+    """``python -m tsl_recognition --help`` must exit with code 0."""
+    result = subprocess.run(
+        [sys.executable, "-m", "tsl_recognition", "--help"],
+        capture_output=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"--help exited {result.returncode}\nstdout: {result.stdout.decode()}\n"
+        f"stderr: {result.stderr.decode()}"
+    )

--- a/tests/test_translation_smoke.py
+++ b/tests/test_translation_smoke.py
@@ -1,0 +1,66 @@
+"""Smoke tests for the gloss_to_text pipeline.
+
+These tests verify that modules import cleanly and that the prompt
+strategies dictionary is populated with the expected keys.  No model
+weights, no GPU, no external API calls required.
+"""
+
+from __future__ import annotations
+
+import pytest  # noqa: F401 — imported for consistency; used if future tests need it
+
+
+# ---------------------------------------------------------------------------
+# 1. Import smoke
+# ---------------------------------------------------------------------------
+
+def test_gloss_to_text_imports() -> None:
+    """gloss_to_text package-level import must succeed."""
+    import gloss_to_text  # noqa: F401
+
+
+def test_gloss_to_text_prompts_submodule_imports() -> None:
+    """gloss_to_text.prompts.strategies must be importable."""
+    from gloss_to_text.prompts import strategies  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# 2. Prompt strategies
+# ---------------------------------------------------------------------------
+
+_EXPECTED_STRATEGY_KEYS: frozenset[str] = frozenset(
+    {"P1_EN", "P1_TR", "P2_EN", "P2_TR", "P3_EN", "P3_TR"}
+)
+
+
+def test_prompt_strategies_has_all_keys() -> None:
+    """PROMPT_STRATEGIES must contain all six P×_EN/TR keys."""
+    from gloss_to_text.prompts.strategies import PROMPT_STRATEGIES
+
+    assert set(PROMPT_STRATEGIES.keys()) == _EXPECTED_STRATEGY_KEYS
+
+
+def test_prompt_strategies_values_are_non_empty_strings() -> None:
+    """Every prompt strategy value must be a non-empty string."""
+    from gloss_to_text.prompts.strategies import PROMPT_STRATEGIES
+
+    for key, value in PROMPT_STRATEGIES.items():
+        assert isinstance(value, str), f"{key}: expected str, got {type(value)}"
+        assert value.strip(), f"{key}: value is blank"
+
+
+def test_prompt_strategies_dict_is_module_singleton() -> None:
+    """Two imports of PROMPT_STRATEGIES must return the same object (module cache)."""
+    from gloss_to_text.prompts.strategies import PROMPT_STRATEGIES as a
+    from gloss_to_text.prompts.strategies import PROMPT_STRATEGIES as b
+
+    assert a is b
+
+
+def test_p3_en_strategy_is_present_and_non_trivial() -> None:
+    """P3_EN is the best-performing strategy and must have a substantial prompt."""
+    from gloss_to_text.prompts.strategies import PROMPT_STRATEGIES
+
+    prompt = PROMPT_STRATEGIES["P3_EN"]
+    # Longer than a placeholder — at least 50 characters
+    assert len(prompt) >= 50, f"P3_EN prompt suspiciously short: {prompt!r}"


### PR DESCRIPTION
## What does this PR do?

Adds `tests/` with 23 smoke tests across both pipelines. No dataset files or GPU required to run them. Also wires up `[tool.pytest.ini_options]` in `pyproject.toml`, adds dev extras (`pytest`, `pytest-cov`, `ruff`, `mypy`), and drops a Development section into the README.

## Which pipeline does it touch?
- [x] TSL Recognition
- [x] Gloss-to-Text
- [x] Shared scripts/configs

## Experiment details (if applicable)
- Dataset: N/A
- Model variant: N/A
- Key metric change: N/A

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Training configs are reproducible (seeds, hyperparams documented)
- [x] No large binary files committed directly (use LFS or external storage)

Closes #8