### PR TITLE
feat(dataset) + docs: BosphorusSign22k CSV class mapping and data setup README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,46 @@ sozia-research/
 └── notebooks/                  # Exploratory notebooks
 ```
 
+## Data setup
+
+### BosphorusSign22k
+
+```
+data/BosphorusSign22k/
+├── BosphorusSign22k_classes.csv   # ClassID → Turkish/English name mapping
+├── BosphorusSign22k.csv           # full sample manifest
+└── raw/
+    ├── 0001/                      # one folder per ClassID
+    │   ├── User_2_001.mp4
+    │   ├── User_2_002.mp4
+    │   └── ...
+    ├── 0002/
+    └── ...
+```
+
+Classes come from the CSV (`ClassName_tr`); folder names are numeric IDs.
+The signer-based split (User\_3–6 train, User\_2 val, User\_7 test) is computed at runtime.
+
+### AUTSL
+
+```
+data/AUTSL/
+├── SignList_ClassId_TR_EN.csv     # ClassID → Turkish/English name mapping
+├── train_labels.csv
+├── validation_labels.csv
+├── test_labels.csv
+├── train/                         # raw videos — split-first layout (as distributed)
+│   └── signer1_sample1_color.mp4
+├── val/
+└── test/
+```
+
+AUTSL ships with a predefined signer-disjoint split. Class identity comes from
+the label CSVs, not directory names. Use `--split-mode predefined` (the default for AUTSL).
+
+Both datasets produce the same unified output after extraction:
+`data/{Dataset}/processed/{ClassName_tr}/{sample}.npy`
+
 ## Usage
 
 ### TSL Recognition

--- a/tests/test_recognition_smoke.py
+++ b/tests/test_recognition_smoke.py
@@ -19,6 +19,7 @@ import torch
 # 1. Import smoke
 # ---------------------------------------------------------------------------
 
+
 def test_tsl_recognition_imports() -> None:
     """tsl_recognition package-level import must succeed."""
     import tsl_recognition  # noqa: F401
@@ -34,6 +35,7 @@ def test_tsl_recognition_submodules_import() -> None:
 # ---------------------------------------------------------------------------
 # 2. TrainConfig defaults
 # ---------------------------------------------------------------------------
+
 
 def test_train_config_default_construction() -> None:
     """TrainConfig() with no arguments must use documented defaults."""
@@ -92,6 +94,7 @@ def test_train_config_feature_dim_constant() -> None:
 # ---------------------------------------------------------------------------
 # 3. Model registry + GRU forward pass
 # ---------------------------------------------------------------------------
+
 
 def test_model_registry_contains_gru() -> None:
     """MODEL_REGISTRY must expose a 'gru' key."""
@@ -152,6 +155,7 @@ def test_gru_forward_pass_is_finite() -> None:
 # 4. Dataset registry
 # ---------------------------------------------------------------------------
 
+
 def test_dataset_registry_contains_known_datasets() -> None:
     """DATASET_REGISTRY must include 'bosphorus' and 'autsl'."""
     from tsl_recognition.dataset.registry import DATASET_REGISTRY
@@ -174,14 +178,38 @@ def test_get_dataset_info_bosphorus_returns_instance(tmp_path: Path) -> None:
 def _write_bosphorus_classes_csv(base_dir: Path) -> Path:
     """Write a minimal BosphorusSign22k_classes.csv for testing."""
     import csv as _csv
+
     csv_path = base_dir / "data" / "BosphorusSign22k" / "BosphorusSign22k_classes.csv"
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     with open(csv_path, "w", newline="", encoding="utf-8") as f:
-        writer = _csv.DictWriter(f, fieldnames=["SubsetID", "ClassID", "ClassName_tr", "ClassName_eng"])
+        writer = _csv.DictWriter(
+            f, fieldnames=["SubsetID", "ClassID", "ClassName_tr", "ClassName_eng"]
+        )
         writer.writeheader()
-        writer.writerow({"SubsetID": "Health", "ClassID": "0001", "ClassName_tr": "Aci", "ClassName_eng": "Pain"})
-        writer.writerow({"SubsetID": "Finance", "ClassID": "0002", "ClassName_tr": "Acik", "ClassName_eng": "Open"})
-        writer.writerow({"SubsetID": "General", "ClassID": "0003", "ClassName_tr": "Bal", "ClassName_eng": "Honey"})
+        writer.writerow(
+            {
+                "SubsetID": "Health",
+                "ClassID": "0001",
+                "ClassName_tr": "Aci",
+                "ClassName_eng": "Pain",
+            }
+        )
+        writer.writerow(
+            {
+                "SubsetID": "Finance",
+                "ClassID": "0002",
+                "ClassName_tr": "Acik",
+                "ClassName_eng": "Open",
+            }
+        )
+        writer.writerow(
+            {
+                "SubsetID": "General",
+                "ClassID": "0003",
+                "ClassName_tr": "Bal",
+                "ClassName_eng": "Honey",
+            }
+        )
     return csv_path
 
 
@@ -206,6 +234,7 @@ def test_bosphorus_iter_raw_videos_yields_turkish_names(tmp_path: Path) -> None:
     (class_dir / "User_2_001.mp4").touch()
 
     from tsl_recognition.dataset.registry import get_dataset_info
+
     info = get_dataset_info("bosphorus", tmp_path)
 
     results = list(info.iter_raw_videos())
@@ -223,9 +252,10 @@ def test_bosphorus_iter_raw_videos_filters_by_class(tmp_path: Path) -> None:
     for class_id, name in [("0001", "Aci"), ("0002", "Acik")]:
         d = raw_dir / class_id
         d.mkdir(parents=True)
-        (d / f"User_2_001.mp4").touch()
+        (d / "User_2_001.mp4").touch()
 
     from tsl_recognition.dataset.registry import get_dataset_info
+
     info = get_dataset_info("bosphorus", tmp_path)
 
     results = list(info.iter_raw_videos(classes=["Acik"]))
@@ -255,6 +285,7 @@ def test_get_dataset_info_unknown_raises(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # 5. CLI --help exits 0
 # ---------------------------------------------------------------------------
+
 
 def test_cli_help_exits_zero() -> None:
     """``python -m tsl_recognition --help`` must exit with code 0."""

--- a/tests/test_recognition_smoke.py
+++ b/tests/test_recognition_smoke.py
@@ -11,6 +11,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import csv
+
 import pytest
 import torch
 
@@ -177,12 +179,10 @@ def test_get_dataset_info_bosphorus_returns_instance(tmp_path: Path) -> None:
 
 def _write_bosphorus_classes_csv(base_dir: Path) -> Path:
     """Write a minimal BosphorusSign22k_classes.csv for testing."""
-    import csv as _csv
-
     csv_path = base_dir / "data" / "BosphorusSign22k" / "BosphorusSign22k_classes.csv"
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     with open(csv_path, "w", newline="", encoding="utf-8") as f:
-        writer = _csv.DictWriter(
+        writer = csv.DictWriter(
             f, fieldnames=["SubsetID", "ClassID", "ClassName_tr", "ClassName_eng"]
         )
         writer.writeheader()

--- a/tests/test_recognition_smoke.py
+++ b/tests/test_recognition_smoke.py
@@ -171,6 +171,68 @@ def test_get_dataset_info_bosphorus_returns_instance(tmp_path: Path) -> None:
     assert info.name == "bosphorus"
 
 
+def _write_bosphorus_classes_csv(base_dir: Path) -> Path:
+    """Write a minimal BosphorusSign22k_classes.csv for testing."""
+    import csv as _csv
+    csv_path = base_dir / "data" / "BosphorusSign22k" / "BosphorusSign22k_classes.csv"
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = _csv.DictWriter(f, fieldnames=["SubsetID", "ClassID", "ClassName_tr", "ClassName_eng"])
+        writer.writeheader()
+        writer.writerow({"SubsetID": "Health", "ClassID": "0001", "ClassName_tr": "Aci", "ClassName_eng": "Pain"})
+        writer.writerow({"SubsetID": "Finance", "ClassID": "0002", "ClassName_tr": "Acik", "ClassName_eng": "Open"})
+        writer.writerow({"SubsetID": "General", "ClassID": "0003", "ClassName_tr": "Bal", "ClassName_eng": "Honey"})
+    return csv_path
+
+
+def test_bosphorus_class_names_returns_turkish_names(tmp_path: Path) -> None:
+    """class_names() must return Turkish names from the classes CSV, sorted by ClassID."""
+    from tsl_recognition.dataset.registry import get_dataset_info
+
+    _write_bosphorus_classes_csv(tmp_path)
+    info = get_dataset_info("bosphorus", tmp_path)
+
+    names = info.class_names()
+    assert names == ["Aci", "Acik", "Bal"]
+
+
+def test_bosphorus_iter_raw_videos_yields_turkish_names(tmp_path: Path) -> None:
+    """iter_raw_videos() must yield Turkish class names, not numeric ClassIDs."""
+    _write_bosphorus_classes_csv(tmp_path)
+
+    raw_dir = tmp_path / "data" / "BosphorusSign22k" / "raw"
+    class_dir = raw_dir / "0001"
+    class_dir.mkdir(parents=True)
+    (class_dir / "User_2_001.mp4").touch()
+
+    from tsl_recognition.dataset.registry import get_dataset_info
+    info = get_dataset_info("bosphorus", tmp_path)
+
+    results = list(info.iter_raw_videos())
+    assert len(results) == 1
+    sample_id, class_name, video_path = results[0]
+    assert class_name == "Aci"
+    assert sample_id == "User_2_001"
+
+
+def test_bosphorus_iter_raw_videos_filters_by_class(tmp_path: Path) -> None:
+    """iter_raw_videos(classes=['Acik']) must skip classes not in the filter."""
+    _write_bosphorus_classes_csv(tmp_path)
+
+    raw_dir = tmp_path / "data" / "BosphorusSign22k" / "raw"
+    for class_id, name in [("0001", "Aci"), ("0002", "Acik")]:
+        d = raw_dir / class_id
+        d.mkdir(parents=True)
+        (d / f"User_2_001.mp4").touch()
+
+    from tsl_recognition.dataset.registry import get_dataset_info
+    info = get_dataset_info("bosphorus", tmp_path)
+
+    results = list(info.iter_raw_videos(classes=["Acik"]))
+    assert len(results) == 1
+    assert results[0][1] == "Acik"
+
+
 def test_get_dataset_info_autsl_returns_instance(tmp_path: Path) -> None:
     """get_dataset_info('autsl', ...) must return a DatasetInfo without data on disk."""
     from tsl_recognition.dataset.base import DatasetInfo

--- a/tsl_recognition/dataset/autsl.py
+++ b/tsl_recognition/dataset/autsl.py
@@ -82,11 +82,22 @@ class AUTSLInfo(DatasetInfo):
         if self._class_map is not None:
             return self._class_map
         csv_path = self._base / "SignList_ClassId_TR_EN.csv"
+        if not csv_path.exists():
+            raise FileNotFoundError(
+                f"SignList_ClassId_TR_EN.csv not found at {csv_path}. "
+                f"See the 'Data setup' section of the README."
+            )
         self._class_map = {}
-        with open(csv_path, newline="") as f:
+        with open(csv_path, newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f)
             for row in reader:
-                self._class_map[int(row["ClassId"])] = row["TR"]
+                name = row["TR"]
+                if name in self._class_map.values():
+                    raise ValueError(
+                        f"Duplicate TR name {name!r} in {csv_path} "
+                        f"(ClassIds collide on the same processed/ directory)"
+                    )
+                self._class_map[int(row["ClassId"])] = name
         return self._class_map
 
     def _load_split_labels(self, split: str) -> dict[str, int]:
@@ -95,7 +106,7 @@ class AUTSLInfo(DatasetInfo):
             return self._label_cache[split]
         csv_path = self._base / _LABEL_CSV[split]
         labels: dict[str, int] = {}
-        with open(csv_path, newline="") as f:
+        with open(csv_path, newline="", encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line:
@@ -131,19 +142,23 @@ class AUTSLInfo(DatasetInfo):
             for sample_name, class_id in labels.items():
                 class_name = class_map[class_id]
                 signer = self.extract_signer(sample_name)
-                entries.append({
-                    "sample_id": sample_name,
-                    "class_name": class_name,
-                    "class_id": class_id,
-                    "signer": signer or "unknown",
-                    "split_origin": split,
-                })
+                entries.append(
+                    {
+                        "sample_id": sample_name,
+                        "class_name": class_name,
+                        "class_id": class_id,
+                        "signer": signer or "unknown",
+                        "split_origin": split,
+                    }
+                )
             splits[split] = entries
 
         return splits
 
     # -- extraction --------------------------------------------------------
-    def iter_raw_videos(self, classes: list[str] | None = None) -> Iterator[tuple[str, str, Path]]:
+    def iter_raw_videos(
+        self, classes: list[str] | None = None
+    ) -> Iterator[tuple[str, str, Path]]:
         class_map = self._load_class_map()
         allowed_classes = set(classes) if classes is not None else None
 

--- a/tsl_recognition/dataset/bosphorus.py
+++ b/tsl_recognition/dataset/bosphorus.py
@@ -92,7 +92,9 @@ class BosphorusSign22kInfo(DatasetInfo):
         return m.group(1) if m else None
 
     # -- extraction --------------------------------------------------------
-    def iter_raw_videos(self, classes: list[str] | None = None) -> Iterator[tuple[str, str, Path]]:
+    def iter_raw_videos(
+        self, classes: list[str] | None = None
+    ) -> Iterator[tuple[str, str, Path]]:
         """Yield (sample_id, ClassName_tr, video_path) for all raw videos.
 
         Raw directories use numeric ClassIDs (``0001/``, ``0002/``, …);
@@ -108,5 +110,8 @@ class BosphorusSign22kInfo(DatasetInfo):
             if not class_dir.exists():
                 continue
             for video_path in sorted(class_dir.iterdir()):
-                if video_path.is_file() and video_path.suffix.lower() in VIDEO_EXTENSIONS:
+                if (
+                    video_path.is_file()
+                    and video_path.suffix.lower() in VIDEO_EXTENSIONS
+                ):
                     yield video_path.stem, class_name, video_path

--- a/tsl_recognition/dataset/bosphorus.py
+++ b/tsl_recognition/dataset/bosphorus.py
@@ -3,11 +3,13 @@ BosphorusSign22k dataset configuration.
 
 Raw layout::
 
-    data/BosphorusSign22k/raw/{class_name}/{User_X_NNN}.mp4
-    data/BosphorusSign22k/processed/{class_name}/{User_X_NNN}.npy
+    data/BosphorusSign22k/raw/{ClassID}/{User_X_NNN}.mp4
+    data/BosphorusSign22k/processed/{ClassName_tr}/{User_X_NNN}.npy
 
-Classes are derived from subdirectory names. Splits are computed by
-signer ID (``User_2`` through ``User_7``).
+Raw directories use numeric ClassIDs (e.g., ``0001/``).  Turkish class
+names are resolved from ``BosphorusSign22k_classes.csv`` (ClassID →
+ClassName_tr).  Splits are computed by signer ID (``User_2`` through
+``User_7``).
 """
 
 from __future__ import annotations
@@ -62,11 +64,22 @@ class BosphorusSign22kInfo(DatasetInfo):
         if self._class_map is not None:
             return self._class_map
         csv_path = self._base / _CLASS_CSV
+        if not csv_path.exists():
+            raise FileNotFoundError(
+                f"{_CLASS_CSV} not found at {csv_path}. "
+                f"See the 'Data setup' section of the README."
+            )
         self._class_map = {}
         with open(csv_path, newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f)
             for row in reader:
-                self._class_map[row["ClassID"]] = row["ClassName_tr"]
+                name = row["ClassName_tr"]
+                if name in self._class_map.values():
+                    raise ValueError(
+                        f"Duplicate ClassName_tr {name!r} in {csv_path} "
+                        f"(ClassIDs collide on the same processed/ directory)"
+                    )
+                self._class_map[row["ClassID"]] = name
         return self._class_map
 
     # -- classes -----------------------------------------------------------

--- a/tsl_recognition/dataset/bosphorus.py
+++ b/tsl_recognition/dataset/bosphorus.py
@@ -12,6 +12,7 @@ signer ID (``User_2`` through ``User_7``).
 
 from __future__ import annotations
 
+import csv
 import re
 from collections.abc import Iterator
 from pathlib import Path
@@ -23,12 +24,15 @@ _SIGNER_RE = re.compile(r"^(User_\d+)_")
 
 VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv"}
 
+_CLASS_CSV = "BosphorusSign22k_classes.csv"
+
 
 class BosphorusSign22kInfo(DatasetInfo):
     """Dataset info for the BosphorusSign22k corpus."""
 
     def __init__(self, base_dir: Path) -> None:
         self._base = base_dir / "data" / "BosphorusSign22k"
+        self._class_map: dict[str, str] | None = None  # ClassID → ClassName_tr
 
     # -- identity ----------------------------------------------------------
     @property
@@ -52,14 +56,24 @@ class BosphorusSign22kInfo(DatasetInfo):
     def split_dir(self) -> Path:
         return self._base / "split"
 
+    # -- CSV helpers -------------------------------------------------------
+    def _load_class_map(self) -> dict[str, str]:
+        """Load ClassID → ClassName_tr from BosphorusSign22k_classes.csv."""
+        if self._class_map is not None:
+            return self._class_map
+        csv_path = self._base / _CLASS_CSV
+        self._class_map = {}
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                self._class_map[row["ClassID"]] = row["ClassName_tr"]
+        return self._class_map
+
     # -- classes -----------------------------------------------------------
     def class_names(self) -> list[str]:
-        for d in (self.raw_dir, self.processed_dir):
-            if d.exists():
-                names = sorted(p.name for p in d.iterdir() if p.is_dir())
-                if names:
-                    return names
-        return []
+        """Return Turkish class names sorted by ClassID."""
+        class_map = self._load_class_map()
+        return [class_map[cid] for cid in sorted(class_map.keys())]
 
     # -- splitting ---------------------------------------------------------
     @property
@@ -79,9 +93,18 @@ class BosphorusSign22kInfo(DatasetInfo):
 
     # -- extraction --------------------------------------------------------
     def iter_raw_videos(self, classes: list[str] | None = None) -> Iterator[tuple[str, str, Path]]:
-        target_classes = classes if classes is not None else self.class_names()
-        for class_name in sorted(target_classes):
-            class_dir = self.raw_dir / class_name
+        """Yield (sample_id, ClassName_tr, video_path) for all raw videos.
+
+        Raw directories use numeric ClassIDs (``0001/``, ``0002/``, …);
+        this method maps them to Turkish class names via the classes CSV.
+        """
+        class_map = self._load_class_map()  # ClassID → ClassName_tr
+        allowed = set(classes) if classes is not None else None
+
+        for class_id, class_name in sorted(class_map.items()):
+            if allowed is not None and class_name not in allowed:
+                continue
+            class_dir = self.raw_dir / class_id
             if not class_dir.exists():
                 continue
             for video_path in sorted(class_dir.iterdir()):


### PR DESCRIPTION
## What does this PR do?

Fixes `BosphorusSign22kInfo` to resolve class names from the CSV instead of numeric folder names. Also adds a data setup section to the README that was missing entirely.

## Which pipeline does it touch?
- [x] TSL Recognition
- [ ] Gloss-to-Text
- [ ] Shared scripts/configs

## Experiment details (if applicable)
N/A

## Changes

**BosphorusSign22k CSV fix (Closes #17)**
- `BosphorusSign22kInfo` now loads `BosphorusSign22k_classes.csv` to map ClassID folders to Turkish class names
- `class_names()` returns Turkish names sorted by ClassID, not the raw folder names (`0001`, `0002`, ...)
- `iter_raw_videos()` looks up the ClassID dir from the CSV and yields the Turkish name as the class label
- Processed files go to `processed/Aci/User_2_001.npy` instead of `processed/0001/User_2_001.npy`
- 3 new tests: class name resolution and video iteration with/without class filter

**README data setup (Closes #18)**
- Documents the expected directory layout for both datasets
- Explains why the layouts differ: BosphorusSign22k is class-first (numeric dirs, runtime split), AUTSL is split-first (as distributed, predefined split)
- Both produce the same `processed/{ClassName_tr}/{sample}.npy` output after extraction

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Training configs are reproducible (seeds, hyperparams documented)
- [x] No large binary files committed directly (use LFS or external storage)