### PR TITLE
fix(ci): drop double-trigger, add permissions and timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, dev, "feat/**"]
+    branches: [main, dev]
   pull_request:
     branches: [main, dev]
 
@@ -10,9 +10,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What does this PR do?

Fixes three issues caught in code review of the CI workflow pushed directly to dev.

## Which pipeline does it touch?
- [ ] TSL Recognition
- [ ] Gloss-to-Text
- [x] Shared scripts/configs

## Changes

- Drop `feat/**` from push triggers — feature branch commits were firing both a push run and a PR run, paying for two jobs on every PR open
- Add `permissions: contents: read` — the job only reads code, no reason to keep the default write scope
- Add `timeout-minutes: 15` — prevents a hung job from sitting for six hours

**Not addressed:** marker strategy for slow tests (point 4 from review) — worth planning before we add heavier integration tests, but nothing to change now.

**Not a real issue:** the `cpython-313` bytecache the reviewer flagged. System Python is 3.13 but the project's conda env and CI both pin 3.11. Someone ran pytest outside the env by mistake.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Training configs are reproducible (seeds, hyperparams documented)
- [x] No large binary files committed directly (use LFS or external storage)