### PR TITLE
feat(lip-reading): add word classifier pipeline

### DIFF
--- a/lip_reading/__init__.py
+++ b/lip_reading/__init__.py
@@ -1,1 +1,27 @@
-# Lip-reading pipeline — placeholder for future implementation.
+"""
+Lip-reading pipeline: face-landmark word classifier trained on TSL sign datasets.
+
+The model uses the 249-dim face-landmark subset (dims 132..381) of the 507-dim
+keypoint vectors already extracted by the TSL recognition pipeline.  Training
+uses sign class names (Turkish words) as word-level supervision, exploiting the
+natural mouthing behaviour of TSL signers.
+
+Quick start::
+
+    python -m lip_reading train                    # full run on BosphorusSign22k
+    python -m lip_reading train --dataset autsl    # full run on AUTSL
+    python -m lip_reading train --test             # 10-class smoke test
+"""
+
+from .config import FACE_SLICE, LIP_FEATURE_DIM, LipTrainConfig
+from .dataset import LipReadingDataset, build_lip_loaders
+from .train import train
+
+__all__ = [
+    "LipTrainConfig",
+    "LIP_FEATURE_DIM",
+    "FACE_SLICE",
+    "LipReadingDataset",
+    "build_lip_loaders",
+    "train",
+]

--- a/lip_reading/__main__.py
+++ b/lip_reading/__main__.py
@@ -1,0 +1,62 @@
+"""
+CLI for the lip-reading pipeline.
+
+Usage::
+
+    python -m lip_reading train                   # full training on BosphorusSign22k
+    python -m lip_reading train --dataset autsl   # full training on AUTSL
+    python -m lip_reading train --test            # 10-class smoke test (BosphorusSign22k)
+    python -m lip_reading train --dataset autsl --test
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from tsl_recognition.dataset.registry import DATASET_CHOICES
+
+from .config import LipTrainConfig
+
+
+def cmd_train(args: argparse.Namespace) -> None:
+    """Execute the lip-reading training command."""
+    from .train import train
+
+    dataset = args.dataset or "bosphorus"
+    if args.test:
+        cfg = LipTrainConfig.test(dataset=dataset)
+    else:
+        cfg = LipTrainConfig.full(dataset=dataset)
+    train(cfg)
+
+
+def main() -> None:
+    """Main CLI entry point for the lip-reading pipeline."""
+    parser = argparse.ArgumentParser(
+        prog="lip_reading",
+        description="Lip-reading word classifier — trained on TSL sign datasets",
+    )
+
+    shared = argparse.ArgumentParser(add_help=False)
+    shared.add_argument(
+        "--test",
+        action="store_true",
+        help="Use 10-class test config instead of full training",
+    )
+    shared.add_argument(
+        "--dataset",
+        choices=DATASET_CHOICES,
+        default="bosphorus",
+        help="Dataset to use (default: bosphorus)",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("train", parents=[shared], help="Train the lip-reading classifier")
+
+    args = parser.parse_args()
+    if args.command == "train":
+        cmd_train(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/lip_reading/config.py
+++ b/lip_reading/config.py
@@ -1,0 +1,173 @@
+"""
+Configuration constants and training hyper-parameters for the lip-reading pipeline.
+
+The lip-reading model is a word classifier trained on the face-landmark subset
+of the existing TSL recognition datasets.  The 83-point face subset spans
+feature dimensions [132:381] (249-dim) in the 507-dim keypoint vector produced
+by the TSL extraction pipeline.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from tsl_recognition.dataset.base import DatasetInfo
+
+# ---------------------------------------------------------------------------
+# Device
+# ---------------------------------------------------------------------------
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_base_dir() -> Path:
+    """Determine the project root directory.
+
+    Resolution order:
+      1. ``PROJECT_ROOT`` environment variable (if set).
+      2. Parent of the ``lip_reading`` package directory (auto-detected).
+      3. Current working directory as a fallback.
+    """
+    env_root = os.environ.get("PROJECT_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.exists():
+            return p
+    pkg_dir = Path(__file__).resolve().parent  # .../sozia-research/lip_reading
+    candidate = pkg_dir.parent  # .../sozia-research
+    if (candidate / "lip_reading").is_dir():
+        return candidate
+    return Path.cwd()
+
+
+BASE_DIR = _resolve_base_dir()
+
+# ---------------------------------------------------------------------------
+# Feature dimensions
+# ---------------------------------------------------------------------------
+# Slice of the 507-dim keypoint vector that contains the 83-point face subset.
+# Layout in the 507-dim vector:
+#   [0:132]   pose (33 × 4)
+#   [132:381] face (83 × 3)  ← lip-reading features
+#   [381:444] left hand (21 × 3)
+#   [444:507] right hand (21 × 3)
+FACE_SLICE = slice(132, 381)
+LIP_FEATURE_DIM = 249  # 83 landmarks × 3 (x, y, z)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+LIP_MODELS_DIR = BASE_DIR / "models" / "lip_reading"
+LIP_SCALERS_DIR = BASE_DIR / "scalers" / "lip_reading"
+
+
+# ---------------------------------------------------------------------------
+# Training configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LipTrainConfig:
+    """Training hyper-parameters for the lip-reading word classifier.
+
+    Attribute names that overlap with ``TrainConfig`` are intentionally
+    kept identical so that shared helpers work via duck-typing without
+    modification.
+    """
+
+    # Dataset
+    dataset: str = "bosphorus"
+    classes_to_process: list[str] = field(default_factory=list)
+
+    # Sequence handling
+    max_sequence_length: int = 150
+    min_sequence_length: int = 10
+    sequence_handling: str = "truncate"
+
+    # Training
+    batch_size: int = 64
+    epochs: int = 300
+    learning_rate: float = 5e-4
+    grad_clip_norm: float = 1.0
+    label_smoothing: float = 0.1
+    dropout: float = 0.4
+
+    # Early stopping
+    early_stopping_patience: int = 35
+    min_epochs: int = 200
+    val_every: int = 5
+
+    # LR scheduling (kept identical to TrainConfig for duck-typing)
+    lr_scheduler: str = "onecycle"
+    warmup_epochs: int = 10
+    warmup_start_factor: float = 0.1
+    onecycle_max_lr: float | None = None
+    onecycle_div_factor: float = 25.0
+    onecycle_final_div_factor: float = 1e4
+    cosine_t0: int = 10
+    cosine_t_mult: int = 2
+    cosine_eta_min: float = 1e-6
+
+    # Data
+    use_class_weights: bool = True
+    normalize_features: bool = True
+    num_workers: int = 4
+    # Augmentation disabled until tuned for face-only features.
+    augment_train: bool = False
+    split_mode: str = "signer"
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def dataset_info(self) -> "DatasetInfo":
+        """Return the ``DatasetInfo`` instance for the selected dataset."""
+        from tsl_recognition.dataset.registry import get_dataset_info
+
+        return get_dataset_info(self.dataset, BASE_DIR)
+
+    @staticmethod
+    def _all_classes(dataset: str = "bosphorus") -> list[str]:
+        from tsl_recognition.dataset.registry import get_dataset_info
+
+        try:
+            return get_dataset_info(dataset, BASE_DIR).class_names()
+        except Exception:
+            return []
+
+    @classmethod
+    def full(cls, dataset: str = "bosphorus") -> "LipTrainConfig":
+        """Full training configuration for all classes in the dataset."""
+        return cls(
+            dataset=dataset,
+            classes_to_process=cls._all_classes(dataset),
+        )
+
+    @classmethod
+    def test(cls, n_classes: int = 10, dataset: str = "bosphorus") -> "LipTrainConfig":
+        """Quick smoke-test configuration (10 classes, 50 epochs)."""
+        all_classes = cls._all_classes(dataset)
+        return cls(
+            dataset=dataset,
+            classes_to_process=all_classes[:n_classes],
+            max_sequence_length=100,
+            batch_size=32,
+            epochs=50,
+            early_stopping_patience=10,
+            min_epochs=30,
+        )
+
+    @property
+    def num_classes(self) -> int:
+        """Total number of word classes to train on."""
+        return len(self.classes_to_process)

--- a/lip_reading/dataset.py
+++ b/lip_reading/dataset.py
@@ -1,0 +1,317 @@
+"""
+Dataset loader for the lip-reading pipeline.
+
+Reuses train/val/test split manifests from the TSL recognition pipeline.
+Face-landmark features (249-dim) are sliced inline from the existing 507-dim
+keypoint files, avoiding disk duplication.
+"""
+
+from __future__ import annotations
+
+import json
+import pickle
+from collections import Counter
+from typing import Any
+
+import numpy as np
+import torch
+from sklearn.preprocessing import StandardScaler
+from torch.utils.data import DataLoader, Dataset
+from tqdm.auto import tqdm
+
+from .config import DEVICE, FACE_SLICE, LIP_FEATURE_DIM, LIP_SCALERS_DIR, LipTrainConfig
+
+
+def _worker_init_fn(worker_id: int) -> None:
+    """Seed NumPy in each DataLoader worker for reproducible augmentation."""
+    worker_info = torch.utils.data.get_worker_info()
+    if worker_info is not None:
+        np.random.seed(worker_info.seed % (2**32))
+
+
+class LipReadingDataset(Dataset):
+    """Memory-efficient dataset that slices face landmarks from 507-dim keypoint files.
+
+    The underlying ``.npy`` files are shared with the TSL recognition pipeline.
+    Face features at ``FACE_SLICE`` (dims 132..381, 249-dim) are extracted per
+    sample at load time, so no separate extraction step is required.
+    """
+
+    def __init__(
+        self,
+        file_info_list: list[tuple[str, int, int]],
+        max_seq_len: int,
+        scaler: StandardScaler | None = None,
+        sequence_handling: str = "truncate",
+    ) -> None:
+        """
+        Parameters
+        ----------
+        file_info_list : list of (path, label, num_frames)
+            Entries from the TSL split manifests.
+        max_seq_len : int
+            Maximum sequence length; longer sequences are truncated or sampled.
+        scaler : StandardScaler | None
+            Pre-fitted scaler for 249-dim face features.
+        sequence_handling : str
+            ``"truncate"`` (keep first N frames) or
+            ``"uniform_sample"`` (evenly sample N frames from the full sequence).
+        """
+        self.file_info = file_info_list
+        self.max_seq_len = max_seq_len
+        self.scaler = scaler
+        self.sequence_handling = sequence_handling
+
+    def __len__(self) -> int:
+        return len(self.file_info)
+
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Load a 507-dim keypoint file, slice face features, pad/truncate.
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+            - keypoints: (max_seq_len, 249)
+            - label: scalar class index
+            - actual_length: number of real (non-padded) frames
+        """
+        path, label, _ = self.file_info[idx]
+
+        # Load 507-dim keypoints and extract the 249-dim face slice
+        keypoints = np.load(path).astype(np.float32)[:, FACE_SLICE]  # (T, 249)
+        num_frames = keypoints.shape[0]
+
+        if num_frames > self.max_seq_len:
+            if self.sequence_handling == "uniform_sample":
+                indices = (
+                    np.linspace(0, num_frames - 1, self.max_seq_len).round().astype(int)
+                )
+                keypoints = keypoints[indices]
+            else:
+                keypoints = keypoints[: self.max_seq_len]
+            num_frames = self.max_seq_len
+
+        actual_length = num_frames
+
+        if self.scaler is not None:
+            keypoints = (keypoints - self.scaler.mean_) / self.scaler.scale_
+
+        if num_frames < self.max_seq_len:
+            padding = np.zeros(
+                (self.max_seq_len - num_frames, LIP_FEATURE_DIM), dtype=np.float32
+            )
+            keypoints = np.vstack([keypoints, padding])
+
+        return (
+            torch.tensor(keypoints, dtype=torch.float32),
+            torch.tensor(label, dtype=torch.long),
+            torch.tensor(actual_length, dtype=torch.long),
+        )
+
+
+def get_or_compute_scaler(
+    train_files: list[tuple[str, int, int]],
+    cfg: LipTrainConfig,
+) -> StandardScaler | None:
+    """Load or compute a ``StandardScaler`` fitted on face-only training features.
+
+    Scalers are stored in ``scalers/lip_reading/<dataset>/scaler_<split>.pkl``.
+    Statistics are computed from training files only to prevent data leakage.
+    """
+    if not cfg.normalize_features:
+        print("Feature normalization: OFF")
+        return None
+
+    scaler_dir = LIP_SCALERS_DIR / cfg.dataset_info.display_name
+    scaler_dir.mkdir(parents=True, exist_ok=True)
+    scaler_path = scaler_dir / f"scaler_{cfg.split_mode}.pkl"
+
+    if scaler_path.exists():
+        print(f"\nLoading pre-computed lip scaler from {scaler_path}...")
+        with open(scaler_path, "rb") as f:
+            scaler: StandardScaler = pickle.load(f)
+        print(f"Scaler loaded: mean shape={scaler.mean_.shape}")
+        return scaler
+
+    print(
+        f"\nComputing lip-reading normalization from {len(train_files)} training files..."
+    )
+    n_total = 0
+    mean = np.zeros(LIP_FEATURE_DIM, dtype=np.float64)
+    M2 = np.zeros(LIP_FEATURE_DIM, dtype=np.float64)
+
+    for path, _, _ in tqdm(train_files, desc="Computing lip stats (train only)"):
+        keypoints = np.load(path, mmap_mode="r")[:, FACE_SLICE]  # (T, 249)
+        num_frames = min(len(keypoints), cfg.max_sequence_length)
+        for i in range(num_frames):
+            n_total += 1
+            delta = keypoints[i].astype(np.float64) - mean
+            mean += delta / n_total
+            delta2 = keypoints[i].astype(np.float64) - mean
+            M2 += delta * delta2
+
+    variance = M2 / n_total
+    std = np.sqrt(variance)
+    std[std < 1e-8] = 1.0
+
+    scaler = StandardScaler()
+    scaler.mean_ = mean.astype(np.float32)
+    scaler.scale_ = std.astype(np.float32)
+    scaler.var_ = variance.astype(np.float32)
+    scaler.n_features_in_ = LIP_FEATURE_DIM
+    scaler.n_samples_seen_ = n_total
+
+    with open(scaler_path, "wb") as f:
+        pickle.dump(scaler, f)
+    print(f"Lip scaler saved to {scaler_path}")
+    return scaler
+
+
+def build_lip_loaders(cfg: LipTrainConfig) -> dict[str, Any]:
+    """Load the TSL split manifests and build lip-reading ``DataLoader`` instances.
+
+    The split manifests are generated by the TSL recognition pipeline
+    (``python -m tsl_recognition split``) and point to 507-dim ``.npy`` files.
+    Face features are sliced inside ``LipReadingDataset.__getitem__``.
+
+    Parameters
+    ----------
+    cfg : LipTrainConfig
+        Training configuration including dataset, class list, and split mode.
+
+    Returns
+    -------
+    dict
+        Keys: ``train_loader``, ``val_loader``, ``test_loader``,
+        ``train_ds``, ``val_ds``, ``test_ds``,
+        ``scaler``, ``class_weights``, ``feature_dim``, ``label_map``,
+        ``train_files``, ``val_files``, ``test_files``, ``split_mode``.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no split manifests exist for the selected dataset.
+    """
+    split_dir = cfg.dataset_info.split_dir
+    meta_path = split_dir / "split_meta.json"
+    if not meta_path.exists():
+        raise FileNotFoundError(
+            f"No split manifests found in {split_dir}. "
+            "Run `python -m tsl_recognition split` first."
+        )
+
+    with open(meta_path) as f:
+        meta = json.load(f)
+    split_mode = str(meta["mode"])
+
+    actions = cfg.classes_to_process
+    allowed_classes = set(actions)
+    label_map = {label: num for num, label in enumerate(actions)}
+
+    def _load_partition(partition: str) -> list[tuple[str, int, int]]:
+        manifest_path = split_dir / f"{partition}.json"
+        with open(manifest_path) as f:
+            entries = json.load(f)
+        kept: list[tuple[str, int, int]] = []
+        dropped = 0
+        for e in entries:
+            cls = e.get("class_name")
+            if cls not in allowed_classes:
+                dropped += 1
+                continue
+            kept.append((e["path"], label_map[cls], int(e["num_frames"])))
+        if dropped:
+            print(
+                f"  Filtered {partition}: dropped {dropped} samples "
+                "outside classes_to_process"
+            )
+        return kept
+
+    train_files = _load_partition("train")
+    val_files = _load_partition("val")
+    test_files = _load_partition("test")
+
+    print(
+        f"\nLoaded {split_mode} split: "
+        f"{len(train_files)} train / {len(val_files)} val / {len(test_files)} test"
+    )
+
+    scaler = get_or_compute_scaler(train_files, cfg)
+
+    train_labels = [f[1] for f in train_files]
+    class_counts = Counter(train_labels)
+    total_train = len(train_files)
+    class_weights = torch.tensor(
+        [
+            total_train / (len(class_counts) * class_counts.get(i, 1))
+            for i in range(cfg.num_classes)
+        ],
+        dtype=torch.float32,
+    ).to(DEVICE)
+    class_weights = class_weights / class_weights.mean()
+    print(
+        f"  Class weights range: [{class_weights.min():.2f}, {class_weights.max():.2f}]"
+    )
+
+    seq_handling = cfg.sequence_handling
+    train_ds = LipReadingDataset(
+        train_files, cfg.max_sequence_length, scaler, seq_handling
+    )
+    val_ds = LipReadingDataset(val_files, cfg.max_sequence_length, scaler, seq_handling)
+    test_ds = LipReadingDataset(
+        test_files, cfg.max_sequence_length, scaler, seq_handling
+    )
+
+    nw = cfg.num_workers
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=cfg.batch_size,
+        shuffle=True,
+        num_workers=nw,
+        pin_memory=True,
+        persistent_workers=nw > 0,
+        worker_init_fn=_worker_init_fn,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=cfg.batch_size,
+        shuffle=False,
+        num_workers=nw,
+        pin_memory=True,
+        persistent_workers=nw > 0,
+        worker_init_fn=_worker_init_fn,
+    )
+    test_loader = DataLoader(
+        test_ds,
+        batch_size=cfg.batch_size,
+        shuffle=False,
+        num_workers=nw,
+        pin_memory=True,
+        persistent_workers=nw > 0,
+        worker_init_fn=_worker_init_fn,
+    )
+
+    print(f"Sequence handling: {seq_handling}")
+    print(f"\nDataset ({split_mode} split):")
+    print(
+        f"  train: ({len(train_files)}, {cfg.max_sequence_length}, {LIP_FEATURE_DIM})"
+    )
+    print(f"  val:   ({len(val_files)}, {cfg.max_sequence_length}, {LIP_FEATURE_DIM})")
+    print(f"  test:  ({len(test_files)}, {cfg.max_sequence_length}, {LIP_FEATURE_DIM})")
+
+    return {
+        "train_loader": train_loader,
+        "val_loader": val_loader,
+        "test_loader": test_loader,
+        "train_ds": train_ds,
+        "val_ds": val_ds,
+        "test_ds": test_ds,
+        "scaler": scaler,
+        "class_weights": class_weights,
+        "feature_dim": LIP_FEATURE_DIM,
+        "label_map": label_map,
+        "train_files": train_files,
+        "val_files": val_files,
+        "test_files": test_files,
+        "split_mode": split_mode,
+    }

--- a/lip_reading/train.py
+++ b/lip_reading/train.py
@@ -1,0 +1,518 @@
+"""
+Training loop for the lip-reading word classifier.
+
+Architecture: ActionGRU (small preset) with input_size=249.
+Labels: sign class names (Turkish words) — one word label per sequence.
+Supervision comes from the existing TSL recognition datasets: signers mouth
+the words they sign, providing natural weak supervision for lip motion.
+
+Artifacts per run::
+
+    models/lip_reading/<dataset>_run_<timestamp>_gru/
+        config.json          # hyper-parameters + metadata
+        vocab.json           # index → class-name mapping (for server inference)
+        best_model.pt        # best checkpoint by val accuracy
+        final_model.pt       # weights at the last training epoch
+        checkpoints/         # periodic snapshots every 50 epochs
+        scores.json          # final test & val metrics + per-class breakdown
+        training_log.csv     # per-epoch metrics
+        plots/
+            loss_curve.png
+            accuracy_curve.png
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import matplotlib
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim.lr_scheduler as lrs
+from sklearn.metrics import accuracy_score, multilabel_confusion_matrix
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from tsl_recognition.config import SEED, set_seed
+from tsl_recognition.evaluation.train import (
+    batch_accuracy,
+    batch_top_k_accuracy,
+    evaluate,
+)
+from tsl_recognition.models import build_model
+
+from .config import DEVICE, LIP_FEATURE_DIM, LIP_MODELS_DIR, LipTrainConfig
+from .dataset import build_lip_loaders
+
+CHECKPOINT_EVERY = 50
+
+
+# ---------------------------------------------------------------------------
+# LR scheduler
+# ---------------------------------------------------------------------------
+
+
+def _build_scheduler(
+    cfg: LipTrainConfig,
+    optimizer: torch.optim.Optimizer,
+    train_loader: torch.utils.data.DataLoader,
+) -> lrs.LRScheduler | None:
+    """Build the LR scheduler matching ``cfg.lr_scheduler``."""
+    name = (cfg.lr_scheduler or "none").lower()
+
+    if name in {"none", "off", "false", "no"}:
+        return None
+
+    if name in {"plateau", "reduceonplateau", "reducelronplateau"}:
+        return lrs.ReduceLROnPlateau(optimizer, mode="min", factor=0.5, patience=15)
+
+    if name in {"onecycle", "onecyclelr"}:
+        steps_per_epoch = len(train_loader)
+        warmup_epochs = max(int(cfg.warmup_epochs), 0)
+        pct_start = float(min(max(warmup_epochs / max(int(cfg.epochs), 1), 1e-3), 0.5))
+        if cfg.onecycle_max_lr is None:
+            cfg.onecycle_max_lr = float(min(5e-3, cfg.learning_rate * 5.0))
+        return lrs.OneCycleLR(
+            optimizer,
+            max_lr=float(cfg.onecycle_max_lr),
+            epochs=cfg.epochs,
+            steps_per_epoch=steps_per_epoch,
+            pct_start=pct_start,
+            div_factor=cfg.onecycle_div_factor,
+            final_div_factor=cfg.onecycle_final_div_factor,
+            anneal_strategy="cos",
+        )
+
+    if name in {"cosine", "cosine_warm_restarts", "cosinewarmrestarts"}:
+        cosine = lrs.CosineAnnealingWarmRestarts(
+            optimizer,
+            T_0=int(cfg.cosine_t0),
+            T_mult=int(cfg.cosine_t_mult),
+            eta_min=float(cfg.cosine_eta_min),
+        )
+        warmup_epochs = max(int(cfg.warmup_epochs), 0)
+        if warmup_epochs > 0:
+            warmup = lrs.LinearLR(
+                optimizer,
+                start_factor=float(cfg.warmup_start_factor),
+                total_iters=warmup_epochs,
+            )
+            return lrs.SequentialLR(
+                optimizer, schedulers=[warmup, cosine], milestones=[warmup_epochs]
+            )
+        return cosine
+
+    raise ValueError(
+        f"Unknown lr_scheduler={cfg.lr_scheduler!r}. "
+        "Expected one of: onecycle, cosine_warm_restarts, plateau, none."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Artifact helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_run_dir(cfg: LipTrainConfig, timestamp: str) -> Path:
+    """Create and return the per-run output directory."""
+    run_dir = LIP_MODELS_DIR / f"{cfg.dataset_info.display_name}_run_{timestamp}_gru"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "checkpoints").mkdir(exist_ok=True)
+    (run_dir / "plots").mkdir(exist_ok=True)
+    return run_dir
+
+
+def _save_vocab(run_dir: Path, classes: list[str]) -> None:
+    """Write index → class-name mapping to ``vocab.json``.
+
+    The server's ``LipReadingEngine`` loads this file to convert classifier
+    output indices back to Turkish word strings.
+    """
+    vocab = {i: name for i, name in enumerate(classes)}
+    (run_dir / "vocab.json").write_text(json.dumps(vocab, indent=2, ensure_ascii=False))
+
+
+def _save_config(run_dir: Path, cfg: LipTrainConfig, total_params: int) -> None:
+    """Serialize hyper-parameters and run metadata to ``config.json``."""
+    meta = asdict(cfg)
+    meta.update(
+        {
+            "model_arch": "gru",
+            "model_size": "small",
+            "feature_dim": LIP_FEATURE_DIM,
+            "total_params": total_params,
+            "device": str(DEVICE),
+        }
+    )
+    (run_dir / "config.json").write_text(json.dumps(meta, indent=2))
+
+
+def _save_training_log(run_dir: Path, log_rows: list[dict]) -> None:
+    """Write per-epoch metrics to ``training_log.csv``."""
+    if not log_rows:
+        return
+    path = run_dir / "training_log.csv"
+    fieldnames = list(log_rows[0].keys())
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(log_rows)
+
+
+def _save_plots(run_dir: Path, log_rows: list[dict]) -> None:
+    """Generate loss and accuracy curve PNGs from the training log."""
+    if not log_rows:
+        return
+
+    epochs = [r["epoch"] for r in log_rows]
+    train_loss = [r["train_loss"] for r in log_rows]
+    train_acc = [r["train_acc"] for r in log_rows]
+    val_loss = [r["val_loss"] for r in log_rows if r["val_loss"] is not None]
+    val_acc = [r["val_acc"] for r in log_rows if r["val_acc"] is not None]
+    val_epochs = [r["epoch"] for r in log_rows if r["val_loss"] is not None]
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.plot(epochs, train_loss, label="Train loss")
+    if val_loss:
+        ax.plot(val_epochs, val_loss, label="Val loss")
+    ax.set_xlabel("Epoch")
+    ax.set_ylabel("Loss")
+    ax.set_title("Loss Curve — Lip Reading")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(run_dir / "plots" / "loss_curve.png", dpi=150)
+    plt.close(fig)
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.plot(epochs, train_acc, label="Train top-1")
+    if val_acc:
+        ax.plot(val_epochs, val_acc, label="Val top-1")
+    ax.set_xlabel("Epoch")
+    ax.set_ylabel("Accuracy")
+    ax.set_title("Accuracy Curve — Lip Reading")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(run_dir / "plots" / "accuracy_curve.png", dpi=150)
+    plt.close(fig)
+
+
+def _save_scores(
+    run_dir: Path,
+    test_acc: float,
+    test_acc5: float,
+    best_val_acc: float,
+    best_val_acc5: float,
+    cm: np.ndarray,
+    actions: list[str],
+) -> None:
+    """Write final evaluation metrics to ``scores.json``."""
+    per_class: dict[str, dict] = {}
+    macro_precision, macro_recall, macro_f1 = 0.0, 0.0, 0.0
+    n_with_support = 0
+
+    for i, label in enumerate(actions):
+        tn, fp, fn, tp = cm[i].ravel()
+        precision = float(tp / (tp + fp)) if (tp + fp) > 0 else 0.0
+        recall = float(tp / (tp + fn)) if (tp + fn) > 0 else 0.0
+        f1 = (
+            float(2 * precision * recall / (precision + recall))
+            if (precision + recall) > 0
+            else 0.0
+        )
+        support = int(tp + fn)
+        per_class[label] = {
+            "precision": round(precision, 4),
+            "recall": round(recall, 4),
+            "f1": round(f1, 4),
+            "support": support,
+        }
+        if support > 0:
+            macro_precision += precision
+            macro_recall += recall
+            macro_f1 += f1
+            n_with_support += 1
+
+    n = max(n_with_support, 1)
+    scores = {
+        "test_accuracy": test_acc,
+        "test_top5_accuracy": test_acc5,
+        "best_val_accuracy": best_val_acc,
+        "best_val_top5_accuracy": best_val_acc5,
+        "num_classes": len(actions),
+        "macro_precision": round(macro_precision / n, 4),
+        "macro_recall": round(macro_recall / n, 4),
+        "macro_f1": round(macro_f1 / n, 4),
+        "per_class": per_class,
+    }
+    (run_dir / "scores.json").write_text(
+        json.dumps(scores, indent=2, ensure_ascii=False)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Training entry point
+# ---------------------------------------------------------------------------
+
+
+def train(cfg: LipTrainConfig | None = None) -> dict:
+    """Train the lip-reading word classifier end-to-end.
+
+    The training loop validates against the **validation** set (for LR
+    scheduling, early stopping, best-model checkpointing).  The **test** set
+    is used only once at the very end for the final reported accuracy.
+
+    All artifacts are written to a dedicated run directory under
+    ``models/lip_reading/``.
+
+    Parameters
+    ----------
+    cfg : LipTrainConfig, optional
+        Training configuration. If *None*, uses ``LipTrainConfig.full()``.
+
+    Returns
+    -------
+    dict
+        ``model``, ``run_dir``, ``model_path``, ``test_accuracy``,
+        ``test_top5_accuracy``, ``best_val_acc``, ``actions``, ``vocab``.
+    """
+    if cfg is None:
+        cfg = LipTrainConfig.full()
+
+    set_seed(SEED)
+
+    run_stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = _create_run_dir(cfg, run_stamp)
+    print(f"\nRun directory: {run_dir}")
+
+    data = build_lip_loaders(cfg)
+    train_loader = data["train_loader"]
+    val_loader = data["val_loader"]
+    test_loader = data["test_loader"]
+    class_weights = data["class_weights"]
+    actions = cfg.classes_to_process
+
+    print(
+        f"\nArchitecture: GRU (small) | "
+        f"input_size={LIP_FEATURE_DIM} | "
+        f"classes={cfg.num_classes}"
+    )
+    print(f"Dropout: {cfg.dropout}")
+
+    model = build_model(
+        arch="gru",
+        input_size=LIP_FEATURE_DIM,
+        num_classes=cfg.num_classes,
+        model_size="small",
+        dropout=cfg.dropout,
+    ).to(DEVICE)
+
+    total_params = sum(p.numel() for p in model.parameters())
+    print(f"Model parameters: {total_params:,}")
+
+    _save_config(run_dir, cfg, total_params)
+    _save_vocab(run_dir, actions)
+
+    ls = cfg.label_smoothing if cfg.label_smoothing > 0 else 0.0
+    if cfg.use_class_weights:
+        criterion = nn.CrossEntropyLoss(weight=class_weights, label_smoothing=ls)
+        print("Using weighted CrossEntropyLoss")
+    else:
+        criterion = nn.CrossEntropyLoss(label_smoothing=ls)
+    if ls > 0:
+        print(f"Label smoothing: {ls}")
+
+    optimizer = torch.optim.Adam(
+        model.parameters(), lr=cfg.learning_rate, weight_decay=1e-4
+    )
+    scheduler = _build_scheduler(cfg, optimizer, train_loader)
+
+    if scheduler is None:
+        print("LR scheduler: none")
+    else:
+        print(f"LR scheduler: {cfg.lr_scheduler}")
+    if cfg.grad_clip_norm > 0:
+        print(f"Gradient clipping: max_norm={cfg.grad_clip_norm}")
+    if cfg.early_stopping_patience > 0:
+        print(
+            f"Early stopping: patience={cfg.early_stopping_patience} "
+            f"(min_epochs={cfg.min_epochs})"
+        )
+
+    best_val_acc = 0.0
+    best_val_acc5 = 0.0
+    best_val_epoch = 0
+    log_rows: list[dict] = []
+    best_model_path = run_dir / "best_model.pt"
+
+    print(f"\nTraining for {cfg.epochs} epochs (lr={cfg.learning_rate})")
+    print("-" * 60)
+
+    for epoch in range(1, cfg.epochs + 1):
+        model.train()
+        running_loss = 0.0
+        running_acc = 0.0
+        running_acc5 = 0.0
+
+        for xb, yb, lengths in train_loader:
+            xb, yb = xb.to(DEVICE), yb.to(DEVICE)
+            lengths = lengths.to(DEVICE)
+            optimizer.zero_grad()
+            logits = model(xb, lengths=lengths)
+            loss = criterion(logits, yb)
+            loss.backward()
+            if cfg.grad_clip_norm > 0:
+                nn.utils.clip_grad_norm_(model.parameters(), cfg.grad_clip_norm)
+            optimizer.step()
+            if isinstance(scheduler, lrs.OneCycleLR):
+                scheduler.step()
+            running_loss += loss.item()
+            detached = logits.detach()
+            running_acc += batch_accuracy(detached, yb)
+            running_acc5 += batch_top_k_accuracy(detached, yb, k=5)
+
+        train_loss = running_loss / len(train_loader)
+        train_acc = running_acc / len(train_loader)
+        train_acc5 = running_acc5 / len(train_loader)
+        current_lr = optimizer.param_groups[0]["lr"]
+
+        val_loss: float | None = None
+        val_acc: float | None = None
+        val_acc5: float | None = None
+
+        if epoch == 1 or epoch % cfg.val_every == 0 or epoch == cfg.epochs:
+            val_loss, val_acc, val_acc5 = evaluate(model, val_loader, criterion)
+            if isinstance(scheduler, lrs.ReduceLROnPlateau):
+                scheduler.step(val_loss)
+
+            if val_acc > best_val_acc:
+                best_val_acc = val_acc
+                best_val_acc5 = val_acc5
+                best_val_epoch = epoch
+                best_marker = " * (saved)"
+                torch.save(model.state_dict(), best_model_path)
+            else:
+                best_marker = ""
+
+            print(
+                f"Epoch {epoch:3d}/{cfg.epochs} | "
+                f"loss {train_loss:.4f} | "
+                f"train {train_acc:.4f} (top5 {train_acc5:.4f}) | "
+                f"val {val_acc:.4f} (top5 {val_acc5:.4f}) | "
+                f"lr {current_lr:.1e}{best_marker}"
+            )
+
+        if scheduler is not None and not isinstance(
+            scheduler, (lrs.OneCycleLR, lrs.ReduceLROnPlateau)
+        ):
+            scheduler.step()
+
+        log_rows.append(
+            {
+                "epoch": epoch,
+                "train_loss": round(train_loss, 6),
+                "train_acc": round(train_acc, 6),
+                "train_acc5": round(train_acc5, 6),
+                "val_loss": round(val_loss, 6) if val_loss is not None else None,
+                "val_acc": round(val_acc, 6) if val_acc is not None else None,
+                "val_acc5": round(val_acc5, 6) if val_acc5 is not None else None,
+                "lr": current_lr,
+            }
+        )
+
+        if epoch % CHECKPOINT_EVERY == 0:
+            ckpt_path = run_dir / "checkpoints" / f"epoch_{epoch:03d}.pt"
+            torch.save(model.state_dict(), ckpt_path)
+
+        if (
+            cfg.early_stopping_patience > 0
+            and best_val_epoch > 0
+            and epoch >= cfg.min_epochs
+            and (epoch - best_val_epoch) >= cfg.early_stopping_patience
+        ):
+            print(
+                f"\nEarly stopping at epoch {epoch}: "
+                f"no improvement for {cfg.early_stopping_patience} epochs "
+                f"(best val_acc={best_val_acc:.4f} at epoch {best_val_epoch})"
+            )
+            break
+
+    print("-" * 60)
+    print(
+        f"Best validation accuracy: "
+        f"{best_val_acc:.4f} top-1, {best_val_acc5:.4f} top-5 "
+        f"(epoch {best_val_epoch})"
+    )
+
+    final_model_path = run_dir / "final_model.pt"
+    torch.save(model.state_dict(), final_model_path)
+    print(f"Final model saved to: {final_model_path}")
+
+    if best_model_path.exists():
+        model.load_state_dict(
+            torch.load(best_model_path, map_location=DEVICE, weights_only=True)
+        )
+        print("Restored best model weights")
+
+    # ------------------------------------------------------------------
+    # Final evaluation on held-out test set
+    # ------------------------------------------------------------------
+    print(f"\n{'=' * 60}")
+    print("FINAL EVALUATION ON HELD-OUT TEST SET")
+    print(f"{'=' * 60}")
+
+    eval_model = build_model(
+        arch="gru",
+        input_size=LIP_FEATURE_DIM,
+        num_classes=cfg.num_classes,
+        model_size="small",
+        dropout=cfg.dropout,
+    ).to(DEVICE)
+    eval_model.load_state_dict(
+        torch.load(best_model_path, map_location=DEVICE, weights_only=True)
+    )
+    eval_model.eval()
+
+    all_logits_list: list[torch.Tensor] = []
+    all_true: list[int] = []
+    with torch.no_grad():
+        for xb, yb, lengths in test_loader:
+            logits = eval_model(xb.to(DEVICE), lengths=lengths.to(DEVICE))
+            all_logits_list.append(logits.cpu())
+            all_true.extend(yb.numpy().tolist())
+
+    all_logits = torch.cat(all_logits_list, dim=0)
+    all_targets = torch.tensor(all_true, dtype=torch.long)
+    all_preds = torch.argmax(all_logits, dim=1).numpy().tolist()
+
+    test_acc = accuracy_score(all_true, all_preds)
+    test_acc5 = batch_top_k_accuracy(all_logits, all_targets, k=5)
+    cm = multilabel_confusion_matrix(
+        all_true, all_preds, labels=list(range(cfg.num_classes))
+    )
+
+    print(f"Test Accuracy (top-1): {test_acc:.4f}")
+    print(f"Test Accuracy (top-5): {test_acc5:.4f}")
+
+    _save_scores(run_dir, test_acc, test_acc5, best_val_acc, best_val_acc5, cm, actions)
+    _save_training_log(run_dir, log_rows)
+    _save_plots(run_dir, log_rows)
+    print(f"\nAll artifacts saved to: {run_dir}")
+
+    return {
+        "model": eval_model,
+        "run_dir": run_dir,
+        "model_path": best_model_path,
+        "test_accuracy": test_acc,
+        "test_top5_accuracy": test_acc5,
+        "best_val_acc": best_val_acc,
+        "actions": actions,
+        "vocab": {i: name for i, name in enumerate(actions)},
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dev = [
     "pytest-cov>=5.0",
     "ruff>=0.4",
     "mypy>=1.10",
+    "scikit-learn>=1.3",
+    "matplotlib>=3.7",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ tsl-recognition = "tsl_recognition.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["tsl_recognition*", "gloss_to_text*"]
+include = ["tsl_recognition*", "gloss_to_text*", "lip_reading*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_lip_reading_smoke.py
+++ b/tests/test_lip_reading_smoke.py
@@ -1,0 +1,255 @@
+"""Smoke tests for the lip_reading pipeline.
+
+These tests verify that modules import cleanly, core objects can be
+constructed with no data on disk, and the 249-dim GRU variant produces
+output of the expected shape.  No GPU, no real dataset files required.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+
+# ---------------------------------------------------------------------------
+# 1. Import smoke
+# ---------------------------------------------------------------------------
+
+
+def test_lip_reading_imports() -> None:
+    """Top-level ``lip_reading`` package import must succeed."""
+    import lip_reading  # noqa: F401
+
+
+def test_lip_reading_submodules_import() -> None:
+    """Core sub-modules must be importable without side-effects."""
+    from lip_reading import config  # noqa: F401
+    from lip_reading.dataset import LipReadingDataset, build_lip_loaders  # noqa: F401
+    from lip_reading.train import train  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# 2. LipTrainConfig defaults
+# ---------------------------------------------------------------------------
+
+
+def test_lip_train_config_defaults() -> None:
+    """LipTrainConfig() must expose the documented default values."""
+    from lip_reading.config import LipTrainConfig
+
+    cfg = LipTrainConfig()
+
+    assert cfg.dataset == "bosphorus"
+    assert cfg.classes_to_process == []
+    assert cfg.max_sequence_length == 150
+    assert cfg.min_sequence_length == 10
+    assert cfg.batch_size == 64
+    assert cfg.epochs == 300
+    assert cfg.lr_scheduler == "onecycle"
+    assert cfg.dropout == pytest.approx(0.4)
+    assert cfg.augment_train is False
+
+
+def test_lip_train_config_num_classes() -> None:
+    """num_classes property must equal len(classes_to_process)."""
+    from lip_reading.config import LipTrainConfig
+
+    cfg = LipTrainConfig(classes_to_process=["Aci", "Acik", "Bal"])
+    assert cfg.num_classes == 3
+
+
+def test_lip_train_config_test_factory() -> None:
+    """LipTrainConfig.test() must use the reduced epoch count."""
+    from lip_reading.config import LipTrainConfig
+
+    cfg = LipTrainConfig.test()
+    assert cfg.epochs == 50
+    assert cfg.max_sequence_length == 100
+
+
+# ---------------------------------------------------------------------------
+# 3. Constants
+# ---------------------------------------------------------------------------
+
+
+def test_lip_feature_dim_is_249() -> None:
+    """LIP_FEATURE_DIM must equal 249 (83 face landmarks × 3 coords)."""
+    from lip_reading.config import LIP_FEATURE_DIM
+
+    assert LIP_FEATURE_DIM == 249
+
+
+def test_face_slice_selects_249_dims() -> None:
+    """FACE_SLICE applied to a 507-dim vector must yield 249 elements."""
+    from lip_reading.config import FACE_SLICE
+
+    dummy = np.zeros(507)
+    assert dummy[FACE_SLICE].shape == (249,)
+
+
+def test_face_slice_matches_tsl_config() -> None:
+    """lip_reading.FACE_SLICE must match tsl_recognition.config.FACE_SLICE."""
+    from lip_reading.config import FACE_SLICE as lip_slice
+    from tsl_recognition.config import FACE_SLICE as tsl_slice
+
+    assert lip_slice == tsl_slice
+
+
+# ---------------------------------------------------------------------------
+# 4. LipReadingDataset with synthetic data
+# ---------------------------------------------------------------------------
+
+
+def _make_synthetic_npy(path: Path, n_frames: int = 20) -> None:
+    """Write a 507-dim synthetic keypoint file at *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.save(path, np.random.rand(n_frames, 507).astype(np.float32))
+
+
+def test_lip_reading_dataset_length(tmp_path: Path) -> None:
+    """LipReadingDataset.__len__ must match the file list length."""
+    from lip_reading.dataset import LipReadingDataset
+
+    p = tmp_path / "seq.npy"
+    _make_synthetic_npy(p, n_frames=30)
+    ds = LipReadingDataset([(str(p), 0, 30)], max_seq_len=50)
+    assert len(ds) == 1
+
+
+def test_lip_reading_dataset_output_shapes(tmp_path: Path) -> None:
+    """LipReadingDataset must return tensors of the expected shapes."""
+    from lip_reading.dataset import LipReadingDataset
+
+    p = tmp_path / "seq.npy"
+    _make_synthetic_npy(p, n_frames=30)
+    ds = LipReadingDataset([(str(p), 2, 30)], max_seq_len=50)
+    x, y, length = ds[0]
+
+    assert x.shape == (50, 249), f"Expected (50, 249), got {x.shape}"
+    assert y.item() == 2
+    assert length.item() == 30
+
+
+def test_lip_reading_dataset_truncates_long_sequence(tmp_path: Path) -> None:
+    """Sequences longer than max_seq_len must be truncated to max_seq_len."""
+    from lip_reading.dataset import LipReadingDataset
+
+    p = tmp_path / "long.npy"
+    _make_synthetic_npy(p, n_frames=200)
+    ds = LipReadingDataset([(str(p), 0, 200)], max_seq_len=50)
+    x, _, length = ds[0]
+
+    assert x.shape == (50, 249)
+    assert length.item() == 50
+
+
+def test_lip_reading_dataset_pads_short_sequence(tmp_path: Path) -> None:
+    """Sequences shorter than max_seq_len must be zero-padded."""
+    from lip_reading.dataset import LipReadingDataset
+
+    p = tmp_path / "short.npy"
+    _make_synthetic_npy(p, n_frames=10)
+    ds = LipReadingDataset([(str(p), 0, 10)], max_seq_len=50)
+    x, _, length = ds[0]
+
+    assert x.shape == (50, 249)
+    assert length.item() == 10
+    # Padding rows must be zero
+    assert torch.all(x[10:] == 0.0)
+
+
+def test_lip_reading_dataset_face_slice_applied(tmp_path: Path) -> None:
+    """Features returned must be the face-landmark slice of the 507-dim vector."""
+    from lip_reading.config import FACE_SLICE
+    from lip_reading.dataset import LipReadingDataset
+
+    p = tmp_path / "seq.npy"
+    raw = np.random.rand(20, 507).astype(np.float32)
+    np.save(p, raw)
+
+    ds = LipReadingDataset([(str(p), 0, 20)], max_seq_len=20)
+    x, _, _ = ds[0]
+
+    expected = raw[:, FACE_SLICE]
+    np.testing.assert_allclose(x.numpy(), expected, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 5. GRU forward pass at 249-dim input
+# ---------------------------------------------------------------------------
+
+
+def test_gru_forward_pass_249_dim() -> None:
+    """ActionGRU with input_size=249 must produce logits of shape (batch, classes)."""
+    from tsl_recognition.models import build_model
+
+    model = build_model(arch="gru", input_size=249, num_classes=10, model_size="small")
+    model.eval()
+
+    dummy = torch.zeros(2, 15, 249)
+    with torch.no_grad():
+        logits = model(dummy)
+
+    assert logits.shape == (2, 10), f"Expected (2, 10), got {logits.shape}"
+
+
+def test_gru_forward_pass_249_dim_is_finite() -> None:
+    """GRU output on zero input must contain no NaN or Inf."""
+    from tsl_recognition.models import build_model
+
+    model = build_model(arch="gru", input_size=249, num_classes=5, model_size="small")
+    model.eval()
+
+    dummy = torch.zeros(2, 15, 249)
+    with torch.no_grad():
+        logits = model(dummy)
+
+    assert torch.isfinite(logits).all(), "logits contain NaN or Inf"
+
+
+# ---------------------------------------------------------------------------
+# 6. vocab.json round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_vocab_json_round_trip(tmp_path: Path) -> None:
+    """vocab.json must map integer strings → class names round-trippably."""
+    from lip_reading.train import _save_vocab
+
+    classes = ["Aci", "Acik", "Bal"]
+    _save_vocab(tmp_path, classes)
+
+    vocab_path = tmp_path / "vocab.json"
+    assert vocab_path.exists()
+
+    with open(vocab_path) as f:
+        loaded = json.load(f)
+
+    # JSON keys are always strings; convert back to int
+    recovered = {int(k): v for k, v in loaded.items()}
+    assert recovered == {0: "Aci", 1: "Acik", 2: "Bal"}
+
+
+# ---------------------------------------------------------------------------
+# 7. CLI --help exits 0
+# ---------------------------------------------------------------------------
+
+
+def test_lip_reading_cli_help_exits_zero() -> None:
+    """``python -m lip_reading --help`` must exit with code 0."""
+    result = subprocess.run(
+        [sys.executable, "-m", "lip_reading", "--help"],
+        capture_output=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"--help exited {result.returncode}\n"
+        f"stdout: {result.stdout.decode()}\n"
+        f"stderr: {result.stderr.decode()}"
+    )


### PR DESCRIPTION
## What does this PR do?

Trains a word classifier on face landmarks already in the TSL .npy files.
The 83-point face subset (dims 132..381) is sliced at load time — no new
extraction step, nothing added to disk. Reuses TSL split manifests; writes
best_model.pt and vocab.json per run so the server's LipReadingEngine can
load weights and do index-to-word lookup.

New files: config.py, dataset.py, train.py, __main__.py. 17 smoke tests, all green.

## Which pipeline does it touch?
- [x] TSL Recognition
- [ ] Gloss-to-Text
- [ ] Shared scripts/configs

## Experiment details (if applicable)
- Dataset: BosphorusSign22k + AUTSL (both work)
- Model variant: ActionGRU small (hidden=256, 4 layers, input=249)
- Key metric change: not yet trained — run `python -m lip_reading train` to produce results

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Training configs are reproducible (seeds, hyperparams documented)
- [x] No large binary files committed directly (use LFS or external storage)