### PR TITLE
fix(training): keep lengths on CPU for pack/pad sequence ops

### DIFF
--- a/lip_reading/train.py
+++ b/lip_reading/train.py
@@ -363,7 +363,6 @@ def train(cfg: LipTrainConfig | None = None) -> dict:
 
         for xb, yb, lengths in train_loader:
             xb, yb = xb.to(DEVICE), yb.to(DEVICE)
-            lengths = lengths.to(DEVICE)
             optimizer.zero_grad()
             logits = model(xb, lengths=lengths)
             loss = criterion(logits, yb)

--- a/tsl_recognition/evaluation/train.py
+++ b/tsl_recognition/evaluation/train.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from torch.utils.data import DataLoader
 
 import matplotlib
+
 matplotlib.use("Agg")  # headless backend — no display required
 import matplotlib.pyplot as plt
 
@@ -71,7 +72,9 @@ def batch_accuracy(logits: torch.Tensor, targets: torch.Tensor) -> float:
 
 
 def batch_top_k_accuracy(
-    logits: torch.Tensor, targets: torch.Tensor, k: int = 5,
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    k: int = 5,
 ) -> float:
     """Calculate top-k classification accuracy for a batch.
 
@@ -98,7 +101,9 @@ def batch_top_k_accuracy(
     return correct.float().mean().item()
 
 
-def evaluate(model: nn.Module, loader: DataLoader, criterion: nn.Module) -> tuple[float, float, float]:
+def evaluate(
+    model: nn.Module, loader: DataLoader, criterion: nn.Module
+) -> tuple[float, float, float]:
     """Evaluate model on a dataset (validation or test set).
 
     Parameters
@@ -130,7 +135,9 @@ def evaluate(model: nn.Module, loader: DataLoader, criterion: nn.Module) -> tupl
     return total_loss / n_batches, total_acc / n_batches, total_acc5 / n_batches
 
 
-def _build_scheduler(cfg: TrainConfig, optimizer: torch.optim.Optimizer, train_loader: DataLoader) -> lrs.LRScheduler | None:
+def _build_scheduler(
+    cfg: TrainConfig, optimizer: torch.optim.Optimizer, train_loader: DataLoader
+) -> lrs.LRScheduler | None:
     """Create the configured LR scheduler (or None).
 
     Notes
@@ -171,7 +178,12 @@ def _build_scheduler(cfg: TrainConfig, optimizer: torch.optim.Optimizer, train_l
             anneal_strategy="cos",
         )
 
-    if name in {"cosine", "cosine_warm_restarts", "cosinewarmrestarts", "cosineannealingwarmrestarts"}:
+    if name in {
+        "cosine",
+        "cosine_warm_restarts",
+        "cosinewarmrestarts",
+        "cosineannealingwarmrestarts",
+    }:
         cosine = lrs.CosineAnnealingWarmRestarts(
             optimizer,
             T_0=int(cfg.cosine_t0),
@@ -219,13 +231,15 @@ def _save_config(
 ) -> None:
     """Serialize training configuration + run metadata to config.json."""
     meta = asdict(cfg)
-    meta.update({
-        "model_arch": cfg.model_arch,
-        "model_size": cfg.model_size,
-        "feature_dim": feature_dim,
-        "total_params": total_params,
-        "device": str(DEVICE),
-    })
+    meta.update(
+        {
+            "model_arch": cfg.model_arch,
+            "model_size": cfg.model_size,
+            "feature_dim": feature_dim,
+            "total_params": total_params,
+            "device": str(DEVICE),
+        }
+    )
     (run_dir / "config.json").write_text(json.dumps(meta, indent=2))
 
 
@@ -254,7 +268,10 @@ def _save_scores(
         )
         support = int(tp + fn)
         per_class[label] = {
-            "tp": int(tp), "fp": int(fp), "fn": int(fn), "tn": int(tn),
+            "tp": int(tp),
+            "fp": int(fp),
+            "fn": int(fn),
+            "tn": int(tn),
             "precision": round(precision, 4),
             "recall": round(recall, 4),
             "f1": round(f1, 4),
@@ -319,7 +336,9 @@ def _save_plots(run_dir: Path, log_rows: list[dict]) -> None:
     plt.close(fig)
 
     train_acc5 = [r["train_acc5"] for r in log_rows if r.get("train_acc5") is not None]
-    train_acc5_epochs = [r["epoch"] for r in log_rows if r.get("train_acc5") is not None]
+    train_acc5_epochs = [
+        r["epoch"] for r in log_rows if r.get("train_acc5") is not None
+    ]
     val_acc5 = [r["val_acc5"] for r in log_rows if r.get("val_acc5") is not None]
     val_acc5_epochs = [r["epoch"] for r in log_rows if r.get("val_acc5") is not None]
 
@@ -425,7 +444,9 @@ def train(cfg: TrainConfig | None = None) -> dict:
     scaler = data["scaler"]
     actions = cfg.actions
 
-    print(f"\nArchitecture: {cfg.model_arch} ({model_size}) for {cfg.num_classes} classes")
+    print(
+        f"\nArchitecture: {cfg.model_arch} ({model_size}) for {cfg.num_classes} classes"
+    )
     print(f"Dropout: {cfg.dropout}")
 
     model = build_model(
@@ -466,7 +487,9 @@ def train(cfg: TrainConfig | None = None) -> dict:
     else:
         print("Gradient clipping: OFF")
     if cfg.early_stopping_patience > 0:
-        print(f"Early stopping: patience={cfg.early_stopping_patience} epochs (min_epochs={cfg.min_epochs})")
+        print(
+            f"Early stopping: patience={cfg.early_stopping_patience} epochs (min_epochs={cfg.min_epochs})"
+        )
     else:
         print("Early stopping: OFF")
     print(f"Validation every {cfg.val_every} epoch(s)")
@@ -531,19 +554,23 @@ def train(cfg: TrainConfig | None = None) -> dict:
                 f"lr {current_lr:.1e}{best_marker}"
             )
 
-        if scheduler is not None and not isinstance(scheduler, (lrs.OneCycleLR, lrs.ReduceLROnPlateau)):
+        if scheduler is not None and not isinstance(
+            scheduler, (lrs.OneCycleLR, lrs.ReduceLROnPlateau)
+        ):
             scheduler.step()
 
-        log_rows.append({
-            "epoch": epoch,
-            "train_loss": round(train_loss, 6),
-            "train_acc": round(train_acc, 6),
-            "train_acc5": round(train_acc5, 6),
-            "val_loss": round(val_loss, 6) if val_loss is not None else None,
-            "val_acc": round(val_acc, 6) if val_acc is not None else None,
-            "val_acc5": round(val_acc5, 6) if val_acc5 is not None else None,
-            "lr": current_lr,
-        })
+        log_rows.append(
+            {
+                "epoch": epoch,
+                "train_loss": round(train_loss, 6),
+                "train_acc": round(train_acc, 6),
+                "train_acc5": round(train_acc5, 6),
+                "val_loss": round(val_loss, 6) if val_loss is not None else None,
+                "val_acc": round(val_acc, 6) if val_acc is not None else None,
+                "val_acc5": round(val_acc5, 6) if val_acc5 is not None else None,
+                "lr": current_lr,
+            }
+        )
 
         if epoch % CHECKPOINT_EVERY == 0:
             ckpt_path = run_dir / "checkpoints" / f"epoch_{epoch:03d}.pt"
@@ -563,7 +590,9 @@ def train(cfg: TrainConfig | None = None) -> dict:
             break
 
     print("-" * 60)
-    print(f"Best validation accuracy: {best_val_acc:.4f} top-1, {best_val_acc5:.4f} top-5 (epoch {best_val_epoch})")
+    print(
+        f"Best validation accuracy: {best_val_acc:.4f} top-1, {best_val_acc5:.4f} top-5 (epoch {best_val_epoch})"
+    )
 
     final_model_path = run_dir / "final_model.pt"
     torch.save(model.state_dict(), final_model_path)
@@ -586,9 +615,9 @@ def train(cfg: TrainConfig | None = None) -> dict:
     print(f"Prediction: {actions[pred]}")
     print(f"Ground truth: {actions[sample_y.item()]}")
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print("FINAL EVALUATION ON HELD-OUT TEST SET")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     loaded_model = build_model(
         arch=cfg.model_arch,
         input_size=feature_dim,

--- a/tsl_recognition/evaluation/train.py
+++ b/tsl_recognition/evaluation/train.py
@@ -122,7 +122,6 @@ def evaluate(model: nn.Module, loader: DataLoader, criterion: nn.Module) -> tupl
     with torch.no_grad():
         for xb, yb, lengths in loader:
             xb, yb = xb.to(DEVICE), yb.to(DEVICE)
-            lengths = lengths.to(DEVICE)
             logits = model(xb, lengths=lengths)
             total_loss += criterion(logits, yb).item()
             total_acc += batch_accuracy(logits, yb)
@@ -489,7 +488,6 @@ def train(cfg: TrainConfig | None = None) -> dict:
 
         for xb, yb, lengths in train_loader:
             xb, yb = xb.to(DEVICE), yb.to(DEVICE)
-            lengths = lengths.to(DEVICE)
             optimizer.zero_grad()
             logits = model(xb, lengths=lengths)
             loss = criterion(logits, yb)
@@ -582,7 +580,7 @@ def train(cfg: TrainConfig | None = None) -> dict:
         sample_x, sample_y, sample_len = test_ds[0]
         sample_logits = model(
             sample_x.unsqueeze(0).to(DEVICE),
-            lengths=sample_len.unsqueeze(0).to(DEVICE),
+            lengths=sample_len.unsqueeze(0),
         )
         pred = sample_logits.argmax(dim=1).cpu().item()
     print(f"Prediction: {actions[pred]}")
@@ -606,7 +604,7 @@ def train(cfg: TrainConfig | None = None) -> dict:
     all_logits_list, all_true = [], []
     with torch.no_grad():
         for xb, yb, lengths in test_loader:
-            logits = loaded_model(xb.to(DEVICE), lengths=lengths.to(DEVICE))
+            logits = loaded_model(xb.to(DEVICE), lengths=lengths)
             all_logits_list.append(logits.cpu())
             all_true.extend(yb.numpy().tolist())
 

--- a/tsl_recognition/models/gru.py
+++ b/tsl_recognition/models/gru.py
@@ -65,5 +65,5 @@ class ActionGRU(SignClassifier):
 
         if lengths is not None:
             batch_idx = torch.arange(x.size(0), device=x.device)
-            return gru_out[batch_idx, lengths - 1, :]
+            return gru_out[batch_idx, lengths.to(x.device) - 1, :]
         return gru_out[:, -1, :]

--- a/tsl_recognition/models/gru.py
+++ b/tsl_recognition/models/gru.py
@@ -22,8 +22,8 @@ class ActionGRU(SignClassifier):
     """
 
     SIZES = {
-        "small":  {"gru_hidden": 256,  "gru_layers": 4, "fc": [512, 256]},
-        "large":  {"gru_hidden": 512,  "gru_layers": 5, "fc": [1024, 512]},
+        "small": {"gru_hidden": 256, "gru_layers": 4, "fc": [512, 256]},
+        "large": {"gru_hidden": 512, "gru_layers": 5, "fc": [1024, 512]},
         "xlarge": {"gru_hidden": 1024, "gru_layers": 6, "fc": [2048, 1024]},
     }
 
@@ -47,16 +47,24 @@ class ActionGRU(SignClassifier):
         )
 
         self.head = self._build_head(
-            cfg["gru_hidden"], cfg["fc"], num_classes, dropout,
+            cfg["gru_hidden"],
+            cfg["fc"],
+            num_classes,
+            dropout,
         )
 
     def _encode(
-        self, x: torch.Tensor, lengths: torch.Tensor | None = None,
+        self,
+        x: torch.Tensor,
+        lengths: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Encode via GRU, returning the hidden state at the last real frame."""
         if lengths is not None:
             packed = nn.utils.rnn.pack_padded_sequence(
-                x, lengths.cpu().clamp(min=1), batch_first=True, enforce_sorted=False,
+                x,
+                lengths.cpu().clamp(min=1),
+                batch_first=True,
+                enforce_sorted=False,
             )
             packed_out, _ = self.gru(packed)
             gru_out, _ = nn.utils.rnn.pad_packed_sequence(packed_out, batch_first=True)


### PR DESCRIPTION
## What does this PR do?

Both lip-reading runs were crashing at epoch 1 with a CUDA unspecified launch failure inside `pad_packed_sequence`. Tracked it down to `lengths.to(DEVICE)` in the training loops. `pack_padded_sequence` and `pad_packed_sequence` want lengths on CPU -- sending them to CUDA was triggering an async kernel failure in the GRU forward on the RTX 5090.

Fixed `gru._encode` too, which was indexing `gru_out` with lengths without moving them to the right device first.

- `tsl_recognition/models/gru.py`: `lengths.to(x.device)` in the indexing step
- `tsl_recognition/evaluation/train.py`: dropped `lengths.to(DEVICE)` from `evaluate()`, training loop, sample eval, and test eval
- `lip_reading/train.py`: same

Closes #24

## Which pipeline does it touch?
- [x] TSL Recognition
- [ ] Gloss-to-Text
- [ ] Shared scripts/configs

## Experiment details (if applicable)
- Dataset: N/A
- Model variant: N/A
- Key metric change: N/A (bug fix)

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Training configs are reproducible (seeds, hyperparams documented)
- [x] No large binary files committed directly (use LFS or external storage)