### PR TITLE
feat(lip-reading): add mouth-only landmark subset to cut overfitting

### DIFF
--- a/lip_reading/__main__.py
+++ b/lip_reading/__main__.py
@@ -3,10 +3,11 @@ CLI for the lip-reading pipeline.
 
 Usage::
 
-    python -m lip_reading train                   # full training on BosphorusSign22k
-    python -m lip_reading train --dataset autsl   # full training on AUTSL
-    python -m lip_reading train --test            # 10-class smoke test (BosphorusSign22k)
-    python -m lip_reading train --dataset autsl --test
+    python -m lip_reading train                              # full training on BosphorusSign22k
+    python -m lip_reading train --dataset autsl              # full training on AUTSL
+    python -m lip_reading train --mouth-only                 # mouth-only landmarks (120-dim)
+    python -m lip_reading train --dataset autsl --mouth-only
+    python -m lip_reading train --test                       # 10-class smoke test
 """
 
 from __future__ import annotations
@@ -27,6 +28,7 @@ def cmd_train(args: argparse.Namespace) -> None:
         cfg = LipTrainConfig.test(dataset=dataset)
     else:
         cfg = LipTrainConfig.full(dataset=dataset)
+    cfg.use_mouth_only = args.mouth_only
     train(cfg)
 
 
@@ -48,6 +50,11 @@ def main() -> None:
         choices=DATASET_CHOICES,
         default="bosphorus",
         help="Dataset to use (default: bosphorus)",
+    )
+    shared.add_argument(
+        "--mouth-only",
+        action="store_true",
+        help="Use only the 40 mouth/lip landmarks (120-dim) instead of full face (249-dim)",
     )
 
     sub = parser.add_subparsers(dest="command", required=True)

--- a/lip_reading/config.py
+++ b/lip_reading/config.py
@@ -64,6 +64,34 @@ FACE_SLICE = slice(132, 381)
 LIP_FEATURE_DIM = 249  # 83 landmarks × 3 (x, y, z)
 
 # ---------------------------------------------------------------------------
+# Mouth-only landmark subset (outer + inner lip contours, 40 landmarks × 3)
+# ---------------------------------------------------------------------------
+# MediaPipe FaceMesh IDs for outer and inner lip contours.
+_MOUTH_LANDMARK_IDS: frozenset[int] = frozenset(
+    {
+        # Outer lip contour (20)
+        0, 17, 37, 39, 40, 61, 84, 91, 146, 181,
+        185, 267, 269, 270, 291, 314, 321, 375, 405, 409,
+        # Inner lip contour (20)
+        13, 14, 78, 80, 81, 82, 87, 88, 95, 178,
+        191, 308, 310, 311, 312, 317, 318, 324, 402, 415,
+    }
+)
+
+# Positions of mouth landmarks within the sorted FACE_LANDMARK_INDICES tuple,
+# then expanded to the flat feature indices inside the 249-dim face vector.
+# Computed at import time — avoids magic numbers in downstream code.
+from tsl_recognition.config import FACE_LANDMARK_INDICES as _FACE_LM_IDX  # noqa: E402
+
+_MOUTH_POSITIONS: tuple[int, ...] = tuple(
+    i for i, lm_id in enumerate(_FACE_LM_IDX) if lm_id in _MOUTH_LANDMARK_IDS
+)
+MOUTH_FEATURE_INDICES: tuple[int, ...] = tuple(
+    fi for p in _MOUTH_POSITIONS for fi in (p * 3, p * 3 + 1, p * 3 + 2)
+)
+MOUTH_FEATURE_DIM: int = len(MOUTH_FEATURE_INDICES)  # 120
+
+# ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
 LIP_MODELS_DIR = BASE_DIR / "models" / "lip_reading"
@@ -124,6 +152,9 @@ class LipTrainConfig:
     # Augmentation disabled until tuned for face-only features.
     augment_train: bool = False
     split_mode: str = "signer"
+    # Feature subset: when True, only the 40 mouth/lip landmarks (120-dim)
+    # are used instead of the full 83-landmark face set (249-dim).
+    use_mouth_only: bool = False
 
     # ------------------------------------------------------------------
     # Helpers
@@ -166,6 +197,16 @@ class LipTrainConfig:
             early_stopping_patience=10,
             min_epochs=30,
         )
+
+    @property
+    def feature_dim(self) -> int:
+        """Input feature dimension: 120 (mouth-only) or 249 (full face)."""
+        return MOUTH_FEATURE_DIM if self.use_mouth_only else LIP_FEATURE_DIM
+
+    @property
+    def feature_indices(self) -> tuple[int, ...] | None:
+        """Feature index subset to apply after face normalization, or None."""
+        return MOUTH_FEATURE_INDICES if self.use_mouth_only else None
 
     @property
     def num_classes(self) -> int:

--- a/lip_reading/dataset.py
+++ b/lip_reading/dataset.py
@@ -19,7 +19,7 @@ from sklearn.preprocessing import StandardScaler
 from torch.utils.data import DataLoader, Dataset
 from tqdm.auto import tqdm
 
-from .config import DEVICE, FACE_SLICE, LIP_FEATURE_DIM, LIP_SCALERS_DIR, LipTrainConfig
+from .config import DEVICE, FACE_SLICE, LIP_FEATURE_DIM, LIP_SCALERS_DIR, LipTrainConfig, MOUTH_FEATURE_DIM
 
 
 def _worker_init_fn(worker_id: int) -> None:
@@ -43,6 +43,7 @@ class LipReadingDataset(Dataset):
         max_seq_len: int,
         scaler: StandardScaler | None = None,
         sequence_handling: str = "truncate",
+        feature_indices: tuple[int, ...] | None = None,
     ) -> None:
         """
         Parameters
@@ -56,11 +57,18 @@ class LipReadingDataset(Dataset):
         sequence_handling : str
             ``"truncate"`` (keep first N frames) or
             ``"uniform_sample"`` (evenly sample N frames from the full sequence).
+        feature_indices : tuple[int, ...] | None
+            Optional index subset applied to the 249-dim face vector after
+            normalization (e.g. mouth-only landmarks). ``None`` keeps all 249.
         """
         self.file_info = file_info_list
         self.max_seq_len = max_seq_len
         self.scaler = scaler
         self.sequence_handling = sequence_handling
+        self.feature_indices = feature_indices
+        self._feature_dim = (
+            len(feature_indices) if feature_indices is not None else LIP_FEATURE_DIM
+        )
 
     def __len__(self) -> int:
         return len(self.file_info)
@@ -96,9 +104,12 @@ class LipReadingDataset(Dataset):
         if self.scaler is not None:
             keypoints = (keypoints - self.scaler.mean_) / self.scaler.scale_
 
+        if self.feature_indices is not None:
+            keypoints = keypoints[:, self.feature_indices]
+
         if num_frames < self.max_seq_len:
             padding = np.zeros(
-                (self.max_seq_len - num_frames, LIP_FEATURE_DIM), dtype=np.float32
+                (self.max_seq_len - num_frames, self._feature_dim), dtype=np.float32
             )
             keypoints = np.vstack([keypoints, padding])
 
@@ -254,12 +265,15 @@ def build_lip_loaders(cfg: LipTrainConfig) -> dict[str, Any]:
     )
 
     seq_handling = cfg.sequence_handling
+    feat_idx = cfg.feature_indices
     train_ds = LipReadingDataset(
-        train_files, cfg.max_sequence_length, scaler, seq_handling
+        train_files, cfg.max_sequence_length, scaler, seq_handling, feat_idx
     )
-    val_ds = LipReadingDataset(val_files, cfg.max_sequence_length, scaler, seq_handling)
+    val_ds = LipReadingDataset(
+        val_files, cfg.max_sequence_length, scaler, seq_handling, feat_idx
+    )
     test_ds = LipReadingDataset(
-        test_files, cfg.max_sequence_length, scaler, seq_handling
+        test_files, cfg.max_sequence_length, scaler, seq_handling, feat_idx
     )
 
     nw = cfg.num_workers
@@ -292,12 +306,11 @@ def build_lip_loaders(cfg: LipTrainConfig) -> dict[str, Any]:
     )
 
     print(f"Sequence handling: {seq_handling}")
+    fdim = cfg.feature_dim
     print(f"\nDataset ({split_mode} split):")
-    print(
-        f"  train: ({len(train_files)}, {cfg.max_sequence_length}, {LIP_FEATURE_DIM})"
-    )
-    print(f"  val:   ({len(val_files)}, {cfg.max_sequence_length}, {LIP_FEATURE_DIM})")
-    print(f"  test:  ({len(test_files)}, {cfg.max_sequence_length}, {LIP_FEATURE_DIM})")
+    print(f"  train: ({len(train_files)}, {cfg.max_sequence_length}, {fdim})")
+    print(f"  val:   ({len(val_files)}, {cfg.max_sequence_length}, {fdim})")
+    print(f"  test:  ({len(test_files)}, {cfg.max_sequence_length}, {fdim})")
 
     return {
         "train_loader": train_loader,
@@ -308,7 +321,7 @@ def build_lip_loaders(cfg: LipTrainConfig) -> dict[str, Any]:
         "test_ds": test_ds,
         "scaler": scaler,
         "class_weights": class_weights,
-        "feature_dim": LIP_FEATURE_DIM,
+        "feature_dim": cfg.feature_dim,
         "label_map": label_map,
         "train_files": train_files,
         "val_files": val_files,

--- a/lip_reading/train.py
+++ b/lip_reading/train.py
@@ -299,16 +299,18 @@ def train(cfg: LipTrainConfig | None = None) -> dict:
     class_weights = data["class_weights"]
     actions = cfg.classes_to_process
 
+    feature_dim = data["feature_dim"]
+
     print(
         f"\nArchitecture: GRU (small) | "
-        f"input_size={LIP_FEATURE_DIM} | "
+        f"input_size={feature_dim} | "
         f"classes={cfg.num_classes}"
     )
     print(f"Dropout: {cfg.dropout}")
 
     model = build_model(
         arch="gru",
-        input_size=LIP_FEATURE_DIM,
+        input_size=feature_dim,
         num_classes=cfg.num_classes,
         model_size="small",
         dropout=cfg.dropout,


### PR DESCRIPTION
## What does this PR do?

The full-face model (249-dim, 83 landmarks) is memorizing signer-specific geometry on the signer-independent split. Train accuracy ~55%, val/test ~6%. This adds a `--mouth-only` flag that restricts input to the 40 outer+inner lip contour landmarks (120-dim), which are the features that actually vary with articulation.

## Which pipeline does it touch?
- [ ] TSL Recognition
- [x] Lip Reading
- [ ] Gloss-to-Text
- [ ] Shared scripts/configs

## Changes

- `lip_reading/config.py`: `MOUTH_FEATURE_INDICES` constant derived from MediaPipe FaceMesh IDs at import time; `use_mouth_only` field on `LipTrainConfig`; `feature_dim` and `feature_indices` properties
- `lip_reading/dataset.py`: `LipReadingDataset` accepts `feature_indices` param, applies subset after normalization, pads to the correct reduced dim
- `lip_reading/train.py`: passes `cfg.feature_dim` as `input_size` instead of hardcoded `LIP_FEATURE_DIM`
- `lip_reading/__main__.py`: `--mouth-only` CLI flag

Usage:
```
python -m lip_reading train --dataset autsl --mouth-only
```

## Experiment details (if applicable)
- Dataset: AUTSL (signer-independent split)
- Model variant: mouth-only (120-dim input vs 249-dim baseline)
- Key metric change: baseline val/test ~6% top-1 — mouth-only result pending

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Training configs are reproducible (seeds, hyperparams documented)
- [x] No large binary files committed directly (use LFS or external storage)

Closes #28